### PR TITLE
Attach jet constituents to jets for substructure calculations

### DIFF
--- a/Histogram.py
+++ b/Histogram.py
@@ -4,7 +4,7 @@ import numpy as np
 import hist
 import matplotlib as mpl
 from coffea.nanoevents import NanoEventsFactory
-from common import DelphesSchema, load_events
+from common import load_events
 
 def ET(vec):
     return np.sqrt(vec.px**2+vec.py**2+vec.mass**2)
@@ -27,8 +27,7 @@ def normalize_angle(angle):
     return angle
 
 def histogram(filename, helper):
-    DelphesSchema.mixins["FatJet"] = "Jet"
-    Events = load_events(filename)
+    Events = load_events(filename, with_constituents=True)
 
     # require two jets
     events = Events
@@ -42,6 +41,7 @@ def histogram(filename, helper):
     E1 = ET(events.Dijet)
     E2 = events.MissingET.MET
     MTsq = (E1+E2)**2-(events.Dijet.px+events.MissingET.px)**2-(events.Dijet.py+events.MissingET.py)**2
+    MTsq = MTsq.to_numpy(allow_missing=True)
     events["MT"] = np.sqrt(MTsq, where=MTsq>=0)
 
     # 4-vectors for dijet

--- a/common.py
+++ b/common.py
@@ -13,6 +13,10 @@ DelphesSchema.mixins.update({
 class DelphesSchema2(DelphesSchema):
     jet_const_pairs = {
         "FatJet" : "ParticleFlowCandidate",
+        "Jet" : "ParticleFlowCandidate",
+        "DarkHadronJet" : "DarkHadronCandidate",
+        "GenFatJet" : "GenCandidate",
+        "GenJet" : "GenCandidate",
     }
 
     # avoid weird error when adding substructure

--- a/common.py
+++ b/common.py
@@ -10,7 +10,71 @@ DelphesSchema.mixins.update({
     "DarkHadronJet": "Jet",
 })
 
-def load_sample(sample,helper=None,schema=DelphesSchema):
+class DelphesSchema2(DelphesSchema):
+    jet_const_pairs = {
+        "FatJet" : "ParticleFlowCandidate",
+    }
+
+    # avoid weird error when adding substructure
+    def __init__(self, base_form):
+        for key in list(base_form["contents"].keys()):
+            if "fBits" in key:
+                base_form["contents"].pop(key, None)
+        super().__init__(base_form)
+
+import numpy as np
+import numba as nb
+from numpy.typing import NDArray
+import awkward as ak
+
+# ignore unnecessary warning
+from numba.core.errors import NumbaTypeSafetyWarning
+import warnings
+warnings.simplefilter('ignore',category=NumbaTypeSafetyWarning)
+# optimized kernel for jet:constituent matching within an event
+@nb.njit("i8[:](i8[:],u4[:])")
+def get_constituents_kernel(jet_refs: NDArray[np.int64], cand_ids: NDArray[np.uint32]) -> NDArray[np.int64]:
+    # get hash table mapping global index : global unique ID
+    hash_table = {k:v for v,k in enumerate(cand_ids)}
+    # apply hash map
+    output = [hash_table[ref] for ref in jet_refs]
+    return np.asarray(output)
+
+# apply kernel to events
+def get_constituents(events, jetsname, candsname):
+    output = []
+    for jets,cands in zip(events[jetsname], events[candsname]):
+        indices = get_constituents_kernel(ak.flatten(jets.Constituents.refs).to_numpy(), cands.fUniqueID.to_numpy()) if jets is not None else []
+        if len(indices)==0:
+            unflattened = None
+        else:
+            unflattened = ak.unflatten(cands[indices],ak.count(jets.Constituents.refs,axis=1),behavior=cands.behavior)[None]
+        output.append(unflattened)
+    # very important for performance to call ak.concatenate only once at the end
+    return ak.with_name(ak.concatenate(output), "Particle")
+
+def init_substructure(events):
+    for jet,const in DelphesSchema2.jet_const_pairs.items():
+        events[jet,"ConstituentsOrig"] = events[jet,"Constituents"]
+        events[jet,"Constituents"] = get_constituents(events,jet,const)
+    return events
+
+# helper to test that all jet constituents were found
+def sum_4vec(vec):
+    summed_vec = {
+        "t": ak.sum(vec.E,axis=-1),
+        "x": ak.sum(vec.px,axis=-1),
+        "y": ak.sum(vec.py,axis=-1),
+        "z": ak.sum(vec.pz,axis=-1),
+    }
+    return ak.zip(summed_vec,with_name="LorentzVector")
+
+def test_substructure(events):
+    for jet in DelphesSchema2.jet_const_pairs:
+        check_jets = sum_4vec(events[jet,"Constituents"])
+        print(jet, check_jets.mass-events[jet].mass)
+
+def load_sample(sample,helper=None,schema=DelphesSchema,with_substructure=False):
     from coffea.nanoevents import NanoEventsFactory
     path = f'models/{sample["model"]}'
     if helper is None:
@@ -20,13 +84,19 @@ def load_sample(sample,helper=None,schema=DelphesSchema):
         sample["helper"] = helper
     metadict = sample["helper"].metadata()
     metadict["dataset"] = sample["name"]
-    sample["events"] = load_events(f'{path}/events.root',schema=schema,metadict=metadict)
+    sample["events"] = load_events(f'{path}/events.root',schema=schema,metadict=metadict,with_substructure=with_substructure)
 
-def load_events(filename,schema=DelphesSchema,metadict=None):
+def load_events(filename,schema=DelphesSchema,metadict=None,with_substructure=False):
     from coffea.nanoevents import NanoEventsFactory
-    return NanoEventsFactory.from_root(
+    if with_substructure and schema==DelphesSchema:
+        schema = DelphesSchema2
+    events = NanoEventsFactory.from_root(
         file=filename,
         treepath="Delphes",
-		schemaclass=schema,
-		metadata=metadict,
-	).events()
+        schemaclass=schema,
+        metadata=metadict,
+    ).events()
+    if with_substructure:
+        events = init_substructure(events)
+    return events
+


### PR DESCRIPTION
This PR implements an efficient hashtable-based algorithm to associate jet constituents to their respective jets using the unique IDs stored in the Delphes output. (Other algorithms considered were: numpy-only (rather than numba) hashtable; `np.searchsorted`, and a "growing" algorithm that shifts the unique IDs to start at 0 and populates missing indices with default values to allow the unique IDs to be used as indices. They all perform similarly, but the numba hashtable was slightly faster on typical data sizes of a few hundred constituents.)

Several Delphes bugs were found and workarounds were implemented. The constituent assignment was tested by comparing jet mass to the mass of the sum of the constituent four-vectors (using the provided functions).