### PR TITLE
Update to Coffea 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ cd model_building
 source init.sh
 ```
 
-This repository is built on the [LCG 105](https://lcginfo.cern.ch/release_packages/105/x86_64-el9-gcc12-opt/) environment.
+This repository is built on the [LCG 106](https://lcginfo.cern.ch/release_packages/106/x86_64-el9-gcc13-opt/) environment.
 Important software versions:
 * Pythia8 3.10
 * Delphes 3.5.1pre09
 * HepMC 2.06.11
-* ROOT 6.30.02
-* coffea 0.7.21
-* uproot 4.3.7
-* awkward 1.10.3
+* ROOT 6.32.02
+* coffea 2025.12.0
+* uproot 5.7.2
+* awkward 2.9.0
 
 ## Predefined model configurations
 

--- a/common.py
+++ b/common.py
@@ -41,19 +41,19 @@ class DelphesSchema2(DelphesSchema):
     }
 
     # avoid weird error when adding constituents
-    def __init__(self, base_form):
-        for key in list(base_form["contents"].keys()):
-            if "fBits" in key:
-                base_form["contents"].pop(key, None)
-        super().__init__(base_form)
+    # def __init__(self, base_form):
+    #     for key in list(base_form["contents"].keys()):
+    #         if "fBits" in key:
+    #             base_form["contents"].pop(key, None)
+    #     super().__init__(base_form)
 
 # ignore unnecessary warning
 from numba.core.errors import NumbaTypeSafetyWarning
 import warnings
 warnings.simplefilter('ignore',category=NumbaTypeSafetyWarning)
 # optimized kernel for jet:constituent matching within an event
-@nb.njit("i8[:](i8[:],u4[:])")
-def get_constituents_kernel(jet_refs: NDArray[np.int64], cand_ids: NDArray[np.uint32]) -> NDArray[np.int64]:
+@nb.njit("i8[:](i4[:],u4[:])")
+def get_constituents_kernel(jet_refs: NDArray[np.int32], cand_ids: NDArray[np.uint32]) -> NDArray[np.int64]:
     # get hash table mapping global index : global unique ID
     hash_table = {k:v for v,k in enumerate(cand_ids)}
     # apply hash map
@@ -110,12 +110,13 @@ def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=Fa
     from coffea.nanoevents import NanoEventsFactory
     if with_constituents and schema==DelphesSchema:
         schema = DelphesSchema2
+
     events = NanoEventsFactory.from_root(
-        file=filename,
-        treepath="Delphes",
+        file={filename : "Delphes"},
         schemaclass=schema,
         metadata=metadict,
     ).events()
+
     if with_constituents:
         events = init_constituents(events)
     return events

--- a/common.py
+++ b/common.py
@@ -4,7 +4,13 @@ import numba as nb
 from numpy.typing import NDArray
 import awkward as ak
 from coffea.nanoevents.methods import vector
-from coffea.nanoevents.methods.delphes import behavior, _set_repr_name, Particle
+from coffea.nanoevents.methods.delphes import behavior, _set_repr_name, Particle, MissingET
+
+# left out of https://github.com/scikit-hep/coffea/pull/1404
+MissingET.ProjectionClass2D = vector.TwoVectorRecord
+MissingET.ProjectionClass3D = vector.ThreeVectorRecord
+MissingET.ProjectionClass4D = MissingET
+MissingET.MomentumClass = vector.LorentzVectorRecord
 
 DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",
@@ -105,6 +111,40 @@ def load_sample(sample,helper=None,schema=DelphesSchema,with_constituents=False)
     metadict["dataset"] = sample["name"]
     sample["events"] = load_events(f'{path}/events.root',schema=schema,metadict=metadict,with_constituents=with_constituents)
 
+def setup_vectors(events):
+    def is_vector(obj):
+        if not hasattr(obj,'fields'): return False
+        fields = [f.lower() for f in obj.fields]
+        prop_lists = [
+            ["eta", "phi"],
+            ["px", "py"],
+        ]
+        return any(all(prop in fields for prop in prop_list) for prop_list in prop_lists)
+
+    def rename_fields(events, name, mapping):
+        obj = events[name]
+        for old,new in mapping:
+            if not old in obj.fields: continue
+            events[name,new] = obj[old]
+        return events
+
+    for name in events.fields:
+        obj = events[name]
+        if not is_vector(obj):
+            continue
+
+        props = ["PT", "Eta", "Phi", "Mass", "Px", "Py", "Pz"]
+        props = [(prop, prop.lower()) for prop in props]
+        # special case: treat MET as 4-vector by setting energy=pt
+        props.extend([
+            ("MET","pt"),
+            ("MET","energy"),
+        ])
+        events = rename_fields(events, name, props)
+        events[name] = ak.with_name(events[name], DelphesSchema.mixins[name])
+
+    return events
+
 def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=False):
     from coffea.nanoevents import NanoEventsFactory
     if with_constituents and schema==DelphesSchema:
@@ -115,6 +155,9 @@ def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=Fa
         schemaclass=schema,
         metadata=metadict,
     ).events()
+
+    # fix missing vector behavior
+    events = setup_vectors(events)
 
     if with_constituents:
         events = init_constituents(events)

--- a/common.py
+++ b/common.py
@@ -41,11 +41,10 @@ class DelphesSchema2(DelphesSchema):
     }
 
     # avoid weird error when adding constituents
-    # def __init__(self, base_form):
-    #     for key in list(base_form["contents"].keys()):
-    #         if "fBits" in key:
-    #             base_form["contents"].pop(key, None)
-    #     super().__init__(base_form)
+    def __init__(self, base_form):
+		# these two lists have to be kept in sync: zip, drop, unzip
+        base_form["fields"], base_form["contents"] = zip(*[entry for entry in zip(base_form["fields"], base_form["contents"]) if not "fBits" in entry[0]])
+        super().__init__(base_form)
 
 # ignore unnecessary warning
 from numba.core.errors import NumbaTypeSafetyWarning

--- a/common.py
+++ b/common.py
@@ -4,13 +4,7 @@ import numba as nb
 from numpy.typing import NDArray
 import awkward as ak
 from coffea.nanoevents.methods import vector
-from coffea.nanoevents.methods.delphes import behavior, _set_repr_name, Particle, MissingET
-
-# left out of https://github.com/scikit-hep/coffea/pull/1404
-MissingET.ProjectionClass2D = vector.TwoVectorRecord
-MissingET.ProjectionClass3D = vector.ThreeVectorRecord
-MissingET.ProjectionClass4D = MissingET
-MissingET.MomentumClass = vector.LorentzVectorRecord
+from coffea.nanoevents.methods.delphes import behavior, _set_repr_name, Particle
 
 DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",
@@ -111,40 +105,6 @@ def load_sample(sample,helper=None,schema=DelphesSchema,with_constituents=False)
     metadict["dataset"] = sample["name"]
     sample["events"] = load_events(f'{path}/events.root',schema=schema,metadict=metadict,with_constituents=with_constituents)
 
-def setup_vectors(events):
-    def is_vector(obj):
-        if not hasattr(obj,'fields'): return False
-        fields = [f.lower() for f in obj.fields]
-        prop_lists = [
-            ["eta", "phi"],
-            ["px", "py"],
-        ]
-        return any(all(prop in fields for prop in prop_list) for prop_list in prop_lists)
-
-    def rename_fields(events, name, mapping):
-        obj = events[name]
-        for old,new in mapping:
-            if not old in obj.fields: continue
-            events[name,new] = obj[old]
-        return events
-
-    for name in events.fields:
-        obj = events[name]
-        if not is_vector(obj):
-            continue
-
-        props = ["PT", "Eta", "Phi", "Mass", "Px", "Py", "Pz"]
-        props = [(prop, prop.lower()) for prop in props]
-        # special case: treat MET as 4-vector by setting energy=pt
-        props.extend([
-            ("MET","pt"),
-            ("MET","energy"),
-        ])
-        events = rename_fields(events, name, props)
-        events[name] = ak.with_name(events[name], DelphesSchema.mixins[name])
-
-    return events
-
 def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=False):
     from coffea.nanoevents import NanoEventsFactory
     if with_constituents and schema==DelphesSchema:
@@ -155,9 +115,6 @@ def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=Fa
         schemaclass=schema,
         metadata=metadict,
     ).events()
-
-    # fix missing vector behavior
-    events = setup_vectors(events)
 
     if with_constituents:
         events = init_constituents(events)

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export LCG_VIEW=LCG_105
-export LCG_ARCH=x86_64-el9-gcc12-opt
+export LCG_VIEW=LCG_106
+export LCG_ARCH=x86_64-el9-gcc13-opt
 source /cvmfs/sft.cern.ch/lcg/views/${LCG_VIEW}/${LCG_ARCH}/setup.sh
 
 export MODEL_BUILDING=$PWD

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -5,6 +5,7 @@ cd python_packages
 
 PKGS=(
 magiconfig \
+coffea==2025.7.0 \
 )
 
 for PKG in ${PKGS[@]}; do

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -5,7 +5,7 @@ cd python_packages
 
 PKGS=(
 magiconfig \
-coffea==2025.7.0 \
+coffea==2025.9.0 \
 )
 
 for PKG in ${PKGS[@]}; do

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -5,7 +5,6 @@ cd python_packages
 
 PKGS=(
 magiconfig \
-coffea==2025.9.0 \
 )
 
 for PKG in ${PKGS[@]}; do
@@ -13,6 +12,7 @@ for PKG in ${PKGS[@]}; do
 done
 
 PKGS_UPGRADE=(
+coffea==2025.12.0 \
 mplhep \
 )
 

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -21,5 +21,5 @@ for PKG in ${PKGS_UPGRADE[@]}; do
 done
 
 cat << 'EOF' > mb_init.sh
-export PYTHONPATH=${MODEL_BUILDING}/install/python_packages/.local/lib/python3.9/site-packages/:${PYTHONPATH}
+export PYTHONPATH=${MODEL_BUILDING}/install/python_packages/.local/lib/python3.11/site-packages/:${PYTHONPATH}
 EOF

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -3,14 +3,6 @@
 mkdir -p python_packages
 cd python_packages
 
-PKGS=(
-magiconfig \
-)
-
-for PKG in ${PKGS[@]}; do
-	HOME=$PWD pip install --user --no-cache-dir $PKG
-done
-
 PKGS_UPGRADE=(
 coffea==2025.12.0 \
 mplhep \
@@ -18,6 +10,15 @@ mplhep \
 
 for PKG in ${PKGS_UPGRADE[@]}; do
 	HOME=$PWD pip install --user --no-cache-dir --upgrade $PKG
+done
+
+PKGS=(
+magiconfig \
+fastjet \
+)
+
+for PKG in ${PKGS[@]}; do
+	HOME=$PWD pip install --user --no-cache-dir $PKG
 done
 
 cat << 'EOF' > mb_init.sh

--- a/run_model
+++ b/run_model
@@ -39,6 +39,7 @@ if __name__=="__main__":
     common.add_argument("--pythia", type=str, nargs='*', default=["cards/CMS_Common.txt","cards/CMS_Tune_CP5.txt"], help="additional settings for Pythia")
     common.add_argument("--delphes", type=str, default="cards/delphes_card_CMS.tcl", help="template card for Delphes")
     common.add_argument("--no-constituents", default=False, action="store_true", help="disable memory-intensive constituent-based computations during histogramming")
+    common.add_argument("--debug", default=False, action="store_true", help="enable detailed debug printouts during histogramming")
 
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
@@ -142,5 +143,5 @@ if __name__=="__main__":
         
     if 'hist' in args["common"].steps:
         
-        Histogram.histogram(root_fname, helper, not args["common"].no_constituents)
+        Histogram.histogram(root_fname, helper, not args["common"].no_constituents, args["common"].debug)
         if args["common"].verbose: print(f'wrote histograms of {root_fname}')


### PR DESCRIPTION
Technical improvements to enable Coffea 2025, with Awkward 2 to enable the fastjet python bindings.

The latest Coffea release incorporates https://github.com/scikit-hep/coffea/pull/1481, which solves an issue we had seen earlier in the 2025 cycle. This release also drops Python 3.9 support, so we needed to move to a newer LCG.

Also adds one missing change from #13.