### PR TITLE
Dark hadron jet study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-/install/pythia8/
-/install/python_packages/
+/install/*/
 *.png
 *.pkl
 *.pdf

--- a/Histogram.py
+++ b/Histogram.py
@@ -165,6 +165,19 @@ def calc_rinv(events, helper, meta_dict, debug):
     dark_mother_sm_sibling = (m1_dark_d_sm) | (m2_dark_d_sm)
     dark_mother_sm_sibling = dark_mother_sm_sibling==1
     printer('dark_mother_sm_sibling',dark_mother_sm_sibling)
+
+    # quick diversion here to measure alpha = E_pi / m_rho for 3-body decays
+    is_dark_3body = is_dark_final & dark_mother_sm_sibling
+    pi_3body = events.GenParticle[is_dark_3body]
+    rho_3body = events.GenParticle[m1[is_dark_3body]]
+    pi_3body_restframe = pi_3body.boostCM_of_beta3(rho_3body.to_beta3())
+    E_pi_3body = pi_3body_restframe.energy
+    m_rho_3body = rho_3body.mass
+    alpha_3body = E_pi_3body/m_rho_3body
+    meta_dict["alpha_3body"] = fill_stats(alpha_3body)
+    print(f"Average alpha_3body = {meta_dict['alpha_3body']['mean']:.3} ({meta_dict['alpha_3body']['stdev']:.3})")
+    events["alpha_3body"] = alpha_3body
+
     is_dark_final = is_dark_final & ~dark_mother_sm_sibling
     printer('is_dark_final',is_dark_final)
 
@@ -186,7 +199,7 @@ def calc_rinv(events, helper, meta_dict, debug):
     meta_dict["stable_invisible_fraction"] = fill_stats(stable_invisible_fraction)
     print(f"Average computed rinv value (pions) = {meta_dict['stable_invisible_fraction']['mean']:.5} ({meta_dict['stable_invisible_fraction']['stdev']:.5})")
 
-    return stable_invisible_fraction
+    events["stable_invisible_fraction"] = stable_invisible_fraction
 
 def calc_mt(jet, met):
     # transverse mass calculation
@@ -296,7 +309,7 @@ def histogram(filename, helper, with_constituents=True, debug=False):
 
     # Add the invisible fraction to the events
     print(f"Predicted rinv = {output['model'].get('rinv_3body',output['model'].get('rinv',-1)):.5}")
-    events["stable_invisible_fraction"] = calc_rinv(events, helper, meta_dict, debug)
+    calc_rinv(events, helper, meta_dict, debug)
 
     # dark hadron jets and corresponding visible and invisible+visible jets
     events["DHJet12"] = ak.pad_none(events.DarkHadronJet[:,0:2], target=2, axis=1)
@@ -459,6 +472,7 @@ def histogram(filename, helper, with_constituents=True, debug=False):
         fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
         fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$r_{\text{inv}}^{\text{gen}}$"),
+        fill_hist("alpha_3body",50,0,1,r"$\alpha_{\text{3body}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
         fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
         fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),

--- a/Histogram.py
+++ b/Histogram.py
@@ -291,48 +291,48 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             .Double()
         )
         h.fill(get_values(var))
-        return h
+        return (var,h)
 
     # Creating hist objects
-    hist_dict = {
-        "MT": fill_hist("MT",50,0,mmed*1.5,r"$m_{\text{T}}$ [GeV]"),
-        "Dijet_pt": fill_hist("Dijet_pt",50,0,mmed*0.75,r"$p_{\text{T}}(JJ)$ [GeV]"),
-        "Dijet_eta": fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
-        "Dijet_phi": fill_hist("Dijet_phi",25,-3.15,3.15,r"$\phi(JJ)$"),
-        "Dijet_mass": fill_hist("Dijet_mass",50,0,mmed*1.5,r"$m_{JJ}$ [GeV]"),
-        "Jet1_pt": fill_hist("Jet1_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_1)$ [GeV]"),
-        "Jet2_pt": fill_hist("Jet2_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_2)$ [GeV]"),
-        "Jet1_eta": fill_hist("Jet1_eta",50,-6,6,r"$\eta(J_1)$"),
-        "Jet2_eta": fill_hist("Jet2_eta",50,-6,6,r"$\eta(J_2)$"),
-        "Jet1_phi": fill_hist("Jet1_phi",25,-3.15,3.15,r"$\phi(J_1)$"),
-        "Jet2_phi": fill_hist("Jet2_phi",25,-3.15,3.15,r"$\phi(J_2)$"),
-        "Jet1_mass": fill_hist("Jet1_mass",50,0,250,r"$m_{J_1}$ [GeV]"),
-        "Jet2_mass": fill_hist("Jet2_mass",50,0,250,r"$m_{J_2}$ [GeV]"),
-        "MET": fill_hist("MET",50,0,mmed*0.75,r"$p_{\text{T}}^{\text{miss}}$ [GeV]"),
-        "DeltaEta": fill_hist("DeltaEta",35,0,8.0,r"$\Delta\eta(JJ)$"),
-        "DeltaPhi": fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
-        "DeltaPhi_MET_Jet1": fill_hist("DeltaPhi_MET_Jet1",25,0,3.15,r"$\Delta\phi(J_1,p_{\text{T}}^{\text{miss}})$"),
-        "DeltaPhi_MET_Jet2": fill_hist("DeltaPhi_MET_Jet2",25,0,3.15,r"$\Delta\phi(J_2,p_{\text{T}}^{\text{miss}})$"),
-    }
+    hist_dict = dict([
+        fill_hist("MT",50,0,mmed*1.5,r"$m_{\text{T}}$ [GeV]"),
+        fill_hist("Dijet_pt",50,0,mmed*0.75,r"$p_{\text{T}}(JJ)$ [GeV]"),
+        fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
+        fill_hist("Dijet_phi",25,-3.15,3.15,r"$\phi(JJ)$"),
+        fill_hist("Dijet_mass",50,0,mmed*1.5,r"$m_{JJ}$ [GeV]"),
+        fill_hist("Jet1_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_1)$ [GeV]"),
+        fill_hist("Jet2_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_2)$ [GeV]"),
+        fill_hist("Jet1_eta",50,-6,6,r"$\eta(J_1)$"),
+        fill_hist("Jet2_eta",50,-6,6,r"$\eta(J_2)$"),
+        fill_hist("Jet1_phi",25,-3.15,3.15,r"$\phi(J_1)$"),
+        fill_hist("Jet2_phi",25,-3.15,3.15,r"$\phi(J_2)$"),
+        fill_hist("Jet1_mass",50,0,250,r"$m_{J_1}$ [GeV]"),
+        fill_hist("Jet2_mass",50,0,250,r"$m_{J_2}$ [GeV]"),
+        fill_hist("MET",50,0,mmed*0.75,r"$p_{\text{T}}^{\text{miss}}$ [GeV]"),
+        fill_hist("DeltaEta",35,0,8.0,r"$\Delta\eta(JJ)$"),
+        fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
+        fill_hist("DeltaPhi_MET_Jet1",25,0,3.15,r"$\Delta\phi(J_1,p_{\text{T}}^{\text{miss}})$"),
+        fill_hist("DeltaPhi_MET_Jet2",25,0,3.15,r"$\Delta\phi(J_2,p_{\text{T}}^{\text{miss}})$"),
+    ])
     if with_constituents:
-        hist_dict.update({
-            "Jet1_girth": fill_hist("Jet1_girth",50,0,1,r"$g_{\text{jet}}(J_1)$"),
-            "Jet2_girth": fill_hist("Jet2_girth",50,0,1,r"$g_{\text{jet}}(J_2)$"),
-            "Jet1_ptD": fill_hist("Jet1_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_1)$"),
-            "Jet2_ptD": fill_hist("Jet2_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_2)$"),
-            "Jet1_major": fill_hist("Jet1_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_1)$"),
-            "Jet2_major": fill_hist("Jet2_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_2)$"),
-            "Jet1_minor": fill_hist("Jet1_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_1)$"),
-            "Jet2_minor": fill_hist("Jet2_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_2)$"),
-        })
-    hist_dict.update({
-        "Jet1_sdmass": fill_hist("Jet1_sdmass",50,0,250,r"$m_{\text{SD}}(J_1)$ [GeV]"),
-        "Jet2_sdmass": fill_hist("Jet2_sdmass",50,0,250,r"$m_{\text{SD}}(J_2)$ [GeV]"),
-        "Jet1_sdpt" : fill_hist("Jet1_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_1)$ [GeV]"),
-        "Jet2_sdpt" : fill_hist("Jet2_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_2)$ [GeV]"),
-        "stable_invisible_fraction": fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
-        "mMediator": fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
-    })
+        hist_dict.update([
+            fill_hist("Jet1_girth",50,0,1,r"$g_{\text{jet}}(J_1)$"),
+            fill_hist("Jet2_girth",50,0,1,r"$g_{\text{jet}}(J_2)$"),
+            fill_hist("Jet1_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_1)$"),
+            fill_hist("Jet2_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_2)$"),
+            fill_hist("Jet1_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_1)$"),
+            fill_hist("Jet2_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_2)$"),
+            fill_hist("Jet1_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_1)$"),
+            fill_hist("Jet2_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_2)$"),
+        ])
+    hist_dict.update([
+        fill_hist("Jet1_sdmass",50,0,250,r"$m_{\text{SD}}(J_1)$ [GeV]"),
+        fill_hist("Jet2_sdmass",50,0,250,r"$m_{\text{SD}}(J_2)$ [GeV]"),
+        fill_hist("Jet1_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_1)$ [GeV]"),
+        fill_hist("Jet2_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_2)$ [GeV]"),
+        fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
+        fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
+    ])
 
     for t in events.fields:
         if 'tau' not in t: continue

--- a/Histogram.py
+++ b/Histogram.py
@@ -194,6 +194,22 @@ def calc_mt(jet, met):
     MTsq = MTsq.to_numpy(allow_missing=True)
     return np.sqrt(MTsq, where=MTsq>=0)
 
+def jet_const_cumsum(array):
+    counts = ak.num(array, axis=-1)
+    flat_counts = ak.flatten(counts, axis=None)
+    flat_array = ak.flatten(array, axis=None)
+    global_cumsum = np.cumsum(flat_array)
+    offsets = np.zeros(len(flat_counts)+1, dtype=int)
+    offsets[1:] = np.cumsum(flat_counts)
+    start_sums = np.zeros_like(global_cumsum)
+    prev_tot = np.zeros(len(flat_counts))
+    prev_tot[1:] = global_cumsum[offsets[1:-1]-1]
+    subtractions = np.repeat(prev_tot, flat_counts)
+    # unflatten in two stages
+    per_jet_flat = global_cumsum - subtractions
+    jets_unflat = ak.unflatten(per_jet_flat, flat_counts)
+    return ak.unflatten(jets_unflat, ak.num(counts, axis=1))
+
 def histogram(filename, helper, with_constituents=True, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
 
@@ -275,32 +291,31 @@ def histogram(filename, helper, with_constituents=True, debug=False):
 
     if with_constituents:
         # dark jet and visible jet radius
+        dr_pcts = [90,95,99]
         for pre in ["DH", "DHV"]:
             print(f"\n{pre}Jet")
-            events[f"{pre}Jet12_radius"] = ak.max(deltaR(events[f"{pre}Jet12"]), axis=-1)
-            events[f"{pre}Jet12_pt"] = events[f"{pre}Jet12"].pt
-
-            # summary of radius
-            flat_max_drs = [ak.flatten(events[f"{pre}Jet12_radius"][:, ind], axis=None) for ind in jet_inds]
-            dr_pcts = [90,95,99]
-            for pct in dr_pcts:
-                print(f"{pct}% radius:", ", ".join(["{:.2f}".format(np.percentile(max_dr, pct)) for max_dr in flat_max_drs]))
-
-            # pt-weighted percentile
+            # pt-weighted percentile per jet
             for pct in dr_pcts:
                 r_pct_pts = []
-                for ind in jet_inds:
-                    flat_dr = ak.to_numpy(ak.flatten(events[f"{pre}Jet12_radius"][:, ind], axis=None))
-                    flat_pt = ak.to_numpy(ak.flatten(events[f"{pre}Jet12_pt"][:, ind], axis=None))
-                    sort_indices = np.argsort(flat_dr)
-                    sorted_dr = flat_dr[sort_indices]
-                    sorted_pt = flat_pt[sort_indices]
-                    cumulative_pt = np.cumsum(sorted_pt)
-                    total_pt = np.sum(sorted_pt)
+                # treat each jet as a slice for consistent dimensionality
+                for ind in [slice(0,1), slice(1,2), slice(0,2)]:
+                    const_dr = deltaR(events[f"{pre}Jet12"][:, ind])
+                    const_px = events[f"{pre}Jet12"][:, ind].Constituents.px
+                    const_py = events[f"{pre}Jet12"][:, ind].Constituents.py
+                    sort_indices = ak.argsort(const_dr, axis=-1)
+                    sorted_dr = const_dr[sort_indices]
+                    sorted_px = const_px[sort_indices]
+                    sorted_py = const_py[sort_indices]
+                    cumul_px = jet_const_cumsum(sorted_px)
+                    cumul_py = jet_const_cumsum(sorted_py)
+                    # running sum of pT within cone
+                    cumul_pt = np.sqrt(cumul_px**2 + cumul_py**2)
+                    # last element of sum is total pT from all constituents
+                    total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
                     target_pt = pct/100 * total_pt
-                    index_pct = np.searchsorted(cumulative_pt, target_pt)
-                    r_pct_pts.append(sorted_dr[index_pct])
-                print(f"{pct}% radius (pt-weighted):", ", ".join(["{:.2f}".format(r_pct_pt) for r_pct_pt in r_pct_pts]))
+                    mask_pt = cumul_pt >= target_pt
+                    r_pct_pts.append(ak.firsts(sorted_dr[mask_pt], axis=-1))
+                print(f"{pct}% radius (pt-weighted):", ", ".join([f"{np.mean(r_pct_pt):.2} ({np.std(r_pct_pt):.2})" for r_pct_pt in r_pct_pts]))
 
             # also compute girth
             events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])

--- a/Histogram.py
+++ b/Histogram.py
@@ -6,6 +6,7 @@ import matplotlib as mpl
 from coffea.nanoevents import NanoEventsFactory
 from common import load_events
 from collections import defaultdict
+from itertools import chain
 
 def ET(vec):
     return np.sqrt(vec.px**2+vec.py**2+vec.mass**2)
@@ -282,75 +283,76 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["stable_invisible_fraction"] = calc_rinv(events, helper, debug)
 
     # dark hadron jets and corresponding visible jets
-    events["DHJet1"] = events.DarkHadronJet[:,0]
-    events["DHJet2"] = events.DarkHadronJet[:,1]
-    events["DHVJet1"] = events.DarkHadronVisibleJet[:,0]
-    events["DHVJet2"] = events.DarkHadronVisibleJet[:,1]
-
-    # keep derived quantities in a dict
-    # otherwise storing concatenation of J1 and J2 will fail b/c different size
-    qtys = {}
+    events["DHJet12"] = events.DarkHadronJet[:,0:2]
+    events["DHVJet12"] = events.DarkHadronVisibleJet[:,0:2]
 
     # per-jet calculation of invisible fraction based on pt
-    dr_inds = ["1","2",""]
-    for ind in [1,2]:
-        qtys[f"DHJet{ind}_rinv"] = 1 - events[f"DHVJet{ind}"].pt / events[f"DHJet{ind}"].pt
-    qtys["DHJet_rinv"] = ak.concatenate([qtys["DHJet1_rinv"], qtys["DHJet2_rinv"]])
-    print("Average jet-level rinv =", ", ".join([f"{np.mean(jrinv):.5} ({np.std(jrinv):.5})" for jrinv in [qtys[f"DHJet{ind}_rinv"] for ind in dr_inds]]))
+    jet_inds = [0, 1, slice(0, 2)]
+    events["DHJet12_rinv"] = 1 - events["DHVJet12"].pt / events["DHJet12"].pt
+    print("Average jet-level rinv =", ", ".join(
+        [f"{np.mean(jrinv):.5} ({np.std(jrinv):.5})" for jrinv in [events["DHJet12_rinv"][:, ind] for ind in jet_inds]]
+    ))
 
     if with_constituents:
         # dark jet and visible jet radius
         for pre in ["DH", "DHV"]:
             print(f"\n{pre}Jet")
-            for ind in [1,2]:
-                qtys[f"{pre}Jet{ind}_radius"] = ak.max(deltaR(events[f"{pre}Jet{ind}"]), axis=-1)
-                qtys[f"{pre}Jet{ind}_pt"] = events[f"{pre}Jet{ind}"].pt
-            qtys[f"{pre}Jet_radius"] = ak.concatenate([qtys[f"{pre}Jet1_radius"], qtys[f"{pre}Jet2_radius"]])
-            qtys[f"{pre}Jet_pt"] = ak.concatenate([qtys[f"{pre}Jet1_pt"], qtys[f"{pre}Jet2_pt"]])
+            events[f"{pre}Jet12_radius"] = ak.max(deltaR(events[f"{pre}Jet12"]), axis=-1)
+            events[f"{pre}Jet12_pt"] = events[f"{pre}Jet12"].pt
 
             # summary of radius
-            flat_max_drs = [ak.flatten(qtys[f"{pre}Jet{ind}_radius"], axis=None) for ind in dr_inds]
+            flat_max_drs = [ak.flatten(events[f"{pre}Jet12_radius"][:, ind], axis=None) for ind in jet_inds]
             dr_pcts = [90,95,99]
             for pct in dr_pcts:
                 print(f"{pct}% radius:", ", ".join(["{:.2f}".format(np.percentile(max_dr, pct)) for max_dr in flat_max_drs]))
 
             # pt-weighted percentile
-            r_pct_pt = defaultdict(dict)
-            for ind in dr_inds:
-                flat_dr = ak.to_numpy(ak.flatten(qtys[f"{pre}Jet{ind}_radius"], axis=None))
-                flat_pt = ak.to_numpy(ak.flatten(qtys[f"{pre}Jet{ind}_pt"], axis=None))
-                sort_indices = np.argsort(flat_dr)
-                sorted_dr = flat_dr[sort_indices]
-                sorted_pt = flat_pt[sort_indices]
-                cumulative_pt = np.cumsum(sorted_pt)
-                total_pt = np.sum(sorted_pt)
-                for pct in dr_pcts:
+            for pct in dr_pcts:
+                r_pct_pts = []
+                for ind in jet_inds:
+                    flat_dr = ak.to_numpy(ak.flatten(events[f"{pre}Jet12_radius"][:, ind], axis=None))
+                    flat_pt = ak.to_numpy(ak.flatten(events[f"{pre}Jet12_pt"][:, ind], axis=None))
+                    sort_indices = np.argsort(flat_dr)
+                    sorted_dr = flat_dr[sort_indices]
+                    sorted_pt = flat_pt[sort_indices]
+                    cumulative_pt = np.cumsum(sorted_pt)
+                    total_pt = np.sum(sorted_pt)
                     target_pt = pct/100 * total_pt
                     index_pct = np.searchsorted(cumulative_pt, target_pt)
-                    r_pct_pt[ind][pct] = sorted_dr[index_pct]
-            for pct in dr_pcts:
-                print(f"{pct}% radius (pt-weighted):", ", ".join(["{:.2f}".format(r_pct_pt[ind][pct]) for ind in dr_inds]))
+                    r_pct_pts.append(sorted_dr[index_pct])
+                print(f"{pct}% radius (pt-weighted):", ", ".join(["{:.2f}".format(r_pct_pt) for r_pct_pt in r_pct_pts]))
 
             # also compute girth
-            for ind in [1,2]:
-                qtys[f"{pre}Jet{ind}_girth"] = calculate_girth(events[f"{pre}Jet{ind}"])
-            qtys[f"{pre}Jet_girth"] = ak.concatenate([qtys[f"{pre}Jet1_girth"], qtys[f"{pre}Jet2_girth"]])
+            events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])
 
     # bind events into filling functions
-    def get_values(var,src):
-        return ak.flatten(src[var],axis=None)
-
-    def fill_hist(var,nbins,bmin,bmax,label,src=events):
+    def fill_single_hist(var,nbins,bmin,bmax,label,ind=None):
         h = (
             hist.Hist.new
             .Reg(nbins, bmin, bmax, label=label)
             .Double()
         )
-        h.fill(get_values(var,src))
-        return (var,h)
+        event_var = events[var]
+        if ind:
+            event_var = events[var][ind]
+        h.fill(ak.flatten(event_var,axis=None))
+        return h
+
+    def fill_hist(var,nbins,bmin,bmax,label):
+        split = "JETIND" in label
+        if not split:
+            # still return a list of pairs for consistency w/ below usage of chain.from_iterable
+            return [(var,fill_single_hist(var,nbins,bmin,bmax,label))]
+        else:
+            results = []
+            jet_ind_names = ["1","2","1,2"]
+            jet_ind_keys = ["1","2","12"]
+            for ind,key,name in zip(jet_inds, jet_ind_keys, jet_ind_names):
+                results.append((var.replace("Jet12",f"Jet{key}"), fill_single_hist(var,nbins,bmin,bmax,label.replace("JETIND",name),ind)))
+            return results
 
     # Creating hist objects
-    hist_dict = dict([
+    hist_dict = dict(chain.from_iterable([
         fill_hist("MT",50,0,mmed*1.5,r"$m_{\text{T}}$ [GeV]"),
         fill_hist("Dijet_pt",50,0,mmed*0.75,r"$p_{\text{T}}(JJ)$ [GeV]"),
         fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
@@ -369,9 +371,9 @@ def histogram(filename, helper, with_constituents=True, debug=False):
         fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
         fill_hist("DeltaPhi_MET_Jet1",25,0,3.15,r"$\Delta\phi(J_1,p_{\text{T}}^{\text{miss}})$"),
         fill_hist("DeltaPhi_MET_Jet2",25,0,3.15,r"$\Delta\phi(J_2,p_{\text{T}}^{\text{miss}})$"),
-    ])
+    ]))
     if with_constituents:
-        hist_dict.update([
+        hist_dict.update(chain.from_iterable([
             fill_hist("Jet1_girth",50,0,1,r"$g_{\text{jet}}(J_1)$"),
             fill_hist("Jet2_girth",50,0,1,r"$g_{\text{jet}}(J_2)$"),
             fill_hist("Jet1_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_1)$"),
@@ -380,30 +382,20 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet2_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_2)$"),
             fill_hist("Jet1_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_1)$"),
             fill_hist("Jet2_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_2)$"),
-            fill_hist("DHJet1_radius",50,0,1,r"${\Delta}R(J_1^{\text{DH}})$",qtys),
-            fill_hist("DHJet2_radius",50,0,1,r"${\Delta}R(J_2^{\text{DH}})$",qtys),
-            fill_hist("DHJet_radius",50,0,1,r"${\Delta}R(J_{1,2}^{\text{DH}})$",qtys),
-            fill_hist("DHVJet1_radius",50,0,1,r"${\Delta}R(J_1^{\text{vis}})$",qtys),
-            fill_hist("DHVJet2_radius",50,0,1,r"${\Delta}R(J_2^{\text{vis}})$",qtys),
-            fill_hist("DHVJet_radius",50,0,1,r"${\Delta}R(J_{1,2}^{\text{vis}})$",qtys),
-            fill_hist("DHJet1_girth",50,0,1,r"$g_{\text{jet}}(J_1^{\text{DH}})$",qtys),
-            fill_hist("DHJet2_girth",50,0,1,r"$g_{\text{jet}}(J_2^{\text{DH}})$",qtys),
-            fill_hist("DHJet_girth",50,0,1,r"$g_{\text{jet}}(J_{1,2}^{\text{DH}})$",qtys),
-            fill_hist("DHVJet1_girth",50,0,1,r"$g_{\text{jet}}(J_1^{\text{vis}})$",qtys),
-            fill_hist("DHVJet2_girth",50,0,1,r"$g_{\text{jet}}(J_2^{\text{vis}})$",qtys),
-            fill_hist("DHVJet_girth",50,0,1,r"$g_{\text{jet}}(J_{1,2}^{\text{vis}})$",qtys),
-        ])
-    hist_dict.update([
+            fill_hist("DHJet12_radius",50,0,1,r"${\Delta}R(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_radius",50,0,3,r"${\Delta}R(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
+        ]))
+    hist_dict.update(chain.from_iterable([
         fill_hist("Jet1_sdmass",50,0,250,r"$m_{\text{SD}}(J_1)$ [GeV]"),
         fill_hist("Jet2_sdmass",50,0,250,r"$m_{\text{SD}}(J_2)$ [GeV]"),
         fill_hist("Jet1_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_1)$ [GeV]"),
         fill_hist("Jet2_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_2)$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
-        fill_hist("DHJet1_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_1^{\text{vis/DH}})$",qtys),
-        fill_hist("DHJet2_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_2^{\text{vis/DH}})$",qtys),
-        fill_hist("DHJet_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{1,2}^{\text{vis/DH}})$",qtys),
-    ])
+        fill_hist("DHJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{vis/DH}})$"),
+    ]))
 
     for t in events.fields:
         if 'tau' not in t: continue

--- a/Histogram.py
+++ b/Histogram.py
@@ -197,7 +197,7 @@ def calc_mt(jet, met):
     return np.sqrt(MTsq, where=MTsq>=0)
 
 def proj(events, jet, const):
-    return events[jet, const].dot(events[jet]) / events[jet].mag2
+    return events[jet, const].dot(events[jet]) / events[jet].mass
 
 def jet_const_cumsum(array):
     counts = ak.num(array, axis=-1)

--- a/Histogram.py
+++ b/Histogram.py
@@ -337,8 +337,8 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             .Double()
         )
         event_var = events[var]
-        if ind:
-            event_var = events[var][ind]
+        if ind is not None:
+            event_var = events[var][:,ind]
         h.fill(ak.flatten(event_var,axis=None))
         return h
 

--- a/Histogram.py
+++ b/Histogram.py
@@ -248,7 +248,7 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["MET"] = events.MissingET.MET
 
     ## For plotting individually for jet1 and jet2
-    events["Jet12"] = events.FatJet[:,0:2]
+    events["Jet12"] = ak.pad_none(events.FatJet[:,0:2], target=2, axis=1)
 
     # 4-vectors for jet1 and jet2
     events["Jet12_pt"] = events["Jet12"].pt
@@ -291,8 +291,8 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["stable_invisible_fraction"] = calc_rinv(events, helper, meta_dict, debug)
 
     # dark hadron jets and corresponding visible jets
-    events["DHJet12"] = events.DarkHadronJet[:,0:2]
-    events["DHVJet12"] = events.DarkHadronVisibleJet[:,0:2]
+    events["DHJet12"] = ak.pad_none(events.DarkHadronJet[:,0:2], target=2, axis=1)
+    events["DHVJet12"] = ak.pad_none(events.DarkHadronVisibleJet[:,0:2], target=2, axis=1)
 
     # per-jet calculation of invisible fraction based on pt
     jet_inds = [0, 1, slice(0, 2)]
@@ -316,22 +316,23 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             print(f"\n{pre}Jet")
             # pt-weighted percentile per jet
             for pct in dr_pcts:
-                const_dr = deltaR(events[f"{pre}Jet12"])
-                const_px = events[f"{pre}Jet12"].Constituents.px
-                const_py = events[f"{pre}Jet12"].Constituents.py
-                sort_indices = ak.argsort(const_dr, axis=-1)
-                sorted_dr = const_dr[sort_indices]
-                sorted_px = const_px[sort_indices]
-                sorted_py = const_py[sort_indices]
-                cumul_px = jet_const_cumsum(sorted_px)
-                cumul_py = jet_const_cumsum(sorted_py)
+                none_mask = ak.is_none(events[f"{pre}Jet12"], axis=1)
+                const_prop = ak.zip({
+                    'dr': deltaR(events[f"{pre}Jet12"]),
+                    'px': events[f"{pre}Jet12"].Constituents.px,
+                    'py': events[f"{pre}Jet12"].Constituents.py,
+                })[~none_mask]
+                sort_indices = ak.argsort(const_prop.dr, axis=-1)
+                sorted_prop = const_prop[sort_indices]
+                cumul_px = jet_const_cumsum(sorted_prop.px)
+                cumul_py = jet_const_cumsum(sorted_prop.py)
                 # running sum of pT within cone
                 cumul_pt = np.sqrt(cumul_px**2 + cumul_py**2)
                 # last element of sum is total pT from all constituents
                 total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
                 target_pt = pct/100 * total_pt
                 mask_pt = cumul_pt >= target_pt
-                events[f"{pre}Jet12_radius{pct}"] = ak.firsts(sorted_dr[mask_pt], axis=-1)
+                events[f"{pre}Jet12_radius{pct}"] = ak.pad_none(ak.firsts(sorted_prop[mask_pt].dr, axis=-1), target=2, axis=1)
                 for ind,key in zip(jet_inds, jet_ind_keys):
                     r_pct_pt = events[f"{pre}Jet12_radius{pct}"][:, ind]
                     meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_pt)
@@ -344,11 +345,11 @@ def histogram(filename, helper, with_constituents=True, debug=False):
 
     # dark hadron jet mass and pt
     events["DHJet12_pt"] = events["DHJet12"].pt
-    events["DiDHJet"] = events.DarkHadronJet[:,0] + events.DarkHadronJet[:,1]
+    events["DiDHJet"] = events["DHJet12"][:,0] + events["DHJet12"][:,1]
     events["DiDHJet_mass"] = events["DiDHJet"].mass
 
     events["DHVJet12_pt"] = events["DHVJet12"].pt
-    events["DiDHVJet"] = events.DarkHadronVisibleJet[:,0] + events.DarkHadronVisibleJet[:,1]
+    events["DiDHVJet"] = events["DHVJet12"][:,0] + events["DHVJet12"][:,1]
     events["DiDHVJet_mass"] = events["DiDHVJet"].mass
     events["DiDHVJet_MT"] = calc_mt(events["DiDHVJet"], events.GenMissingET)
 

--- a/Histogram.py
+++ b/Histogram.py
@@ -296,26 +296,25 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             print(f"\n{pre}Jet")
             # pt-weighted percentile per jet
             for pct in dr_pcts:
-                r_pct_pts = []
-                # treat each jet as a slice for consistent dimensionality
-                for ind in [slice(0,1), slice(1,2), slice(0,2)]:
-                    const_dr = deltaR(events[f"{pre}Jet12"][:, ind])
-                    const_px = events[f"{pre}Jet12"][:, ind].Constituents.px
-                    const_py = events[f"{pre}Jet12"][:, ind].Constituents.py
-                    sort_indices = ak.argsort(const_dr, axis=-1)
-                    sorted_dr = const_dr[sort_indices]
-                    sorted_px = const_px[sort_indices]
-                    sorted_py = const_py[sort_indices]
-                    cumul_px = jet_const_cumsum(sorted_px)
-                    cumul_py = jet_const_cumsum(sorted_py)
-                    # running sum of pT within cone
-                    cumul_pt = np.sqrt(cumul_px**2 + cumul_py**2)
-                    # last element of sum is total pT from all constituents
-                    total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
-                    target_pt = pct/100 * total_pt
-                    mask_pt = cumul_pt >= target_pt
-                    r_pct_pts.append(ak.firsts(sorted_dr[mask_pt], axis=-1))
-                print(f"{pct}% radius (pt-weighted):", ", ".join([f"{np.mean(r_pct_pt):.2} ({np.std(r_pct_pt):.2})" for r_pct_pt in r_pct_pts]))
+                const_dr = deltaR(events[f"{pre}Jet12"])
+                const_px = events[f"{pre}Jet12"].Constituents.px
+                const_py = events[f"{pre}Jet12"].Constituents.py
+                sort_indices = ak.argsort(const_dr, axis=-1)
+                sorted_dr = const_dr[sort_indices]
+                sorted_px = const_px[sort_indices]
+                sorted_py = const_py[sort_indices]
+                cumul_px = jet_const_cumsum(sorted_px)
+                cumul_py = jet_const_cumsum(sorted_py)
+                # running sum of pT within cone
+                cumul_pt = np.sqrt(cumul_px**2 + cumul_py**2)
+                # last element of sum is total pT from all constituents
+                total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
+                target_pt = pct/100 * total_pt
+                mask_pt = cumul_pt >= target_pt
+                events[f"{pre}Jet12_radius{pct}"] = ak.firsts(sorted_dr[mask_pt], axis=-1)
+                print(f"{pct}% radius (pt-weighted):", ", ".join(
+                    [f"{np.mean(r_pct_pt):.2} ({np.std(r_pct_pt):.2})" for r_pct_pt in [events[f"{pre}Jet12_radius{pct}"][:, ind] for ind in jet_inds]]
+                ))
 
             # also compute girth
             events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])
@@ -378,8 +377,12 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
             fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
             fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
-            fill_hist("DHJet12_radius",50,0,1,r"${\Delta}R(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_radius",50,0,3,r"${\Delta}R(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_radius90",50,0,1,r"${\Delta}R_{90}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_radius90",50,0,1,r"${\Delta}R_{90}(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_radius95",50,0,1,r"${\Delta}R_{95}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_radius95",50,0,1,r"${\Delta}R_{95}(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{vis}})$"),
             fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
             fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
         ]))

--- a/Histogram.py
+++ b/Histogram.py
@@ -5,6 +5,7 @@ import hist
 import matplotlib as mpl
 from coffea.nanoevents import NanoEventsFactory
 from common import load_events
+from collections import defaultdict
 
 def ET(vec):
     return np.sqrt(vec.px**2+vec.py**2+vec.mass**2)
@@ -280,17 +281,72 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     # Add the invisible fraction to the events
     events["stable_invisible_fraction"] = calc_rinv(events, helper, debug)
 
-    # bind events into filling functions
-    def get_values(var):
-        return ak.flatten(events[var],axis=None)
+    # dark hadron jets and corresponding visible jets
+    events["DHJet1"] = events.DarkHadronJet[:,0]
+    events["DHJet2"] = events.DarkHadronJet[:,1]
+    events["DHVJet1"] = events.DarkHadronVisibleJet[:,0]
+    events["DHVJet2"] = events.DarkHadronVisibleJet[:,1]
 
-    def fill_hist(var,nbins,bmin,bmax,label):
+    # keep derived quantities in a dict
+    # otherwise storing concatenation of J1 and J2 will fail b/c different size
+    qtys = {}
+
+    # per-jet calculation of invisible fraction based on pt
+    dr_inds = ["1","2",""]
+    for ind in [1,2]:
+        qtys[f"DHJet{ind}_rinv"] = 1 - events[f"DHVJet{ind}"].pt / events[f"DHJet{ind}"].pt
+    qtys["DHJet_rinv"] = ak.concatenate([qtys["DHJet1_rinv"], qtys["DHJet2_rinv"]])
+    print("Average jet-level rinv =", ", ".join([f"{np.mean(jrinv):.5} ({np.std(jrinv):.5})" for jrinv in [qtys[f"DHJet{ind}_rinv"] for ind in dr_inds]]))
+
+    if with_constituents:
+        # dark jet and visible jet radius
+        for pre in ["DH", "DHV"]:
+            print(f"\n{pre}Jet")
+            for ind in [1,2]:
+                qtys[f"{pre}Jet{ind}_radius"] = ak.max(deltaR(events[f"{pre}Jet{ind}"]), axis=-1)
+                qtys[f"{pre}Jet{ind}_pt"] = events[f"{pre}Jet{ind}"].pt
+            qtys[f"{pre}Jet_radius"] = ak.concatenate([qtys[f"{pre}Jet1_radius"], qtys[f"{pre}Jet2_radius"]])
+            qtys[f"{pre}Jet_pt"] = ak.concatenate([qtys[f"{pre}Jet1_pt"], qtys[f"{pre}Jet2_pt"]])
+
+            # summary of radius
+            flat_max_drs = [ak.flatten(qtys[f"{pre}Jet{ind}_radius"], axis=None) for ind in dr_inds]
+            dr_pcts = [90,95,99]
+            for pct in dr_pcts:
+                print(f"{pct}% radius:", ", ".join(["{:.2f}".format(np.percentile(max_dr, pct)) for max_dr in flat_max_drs]))
+
+            # pt-weighted percentile
+            r_pct_pt = defaultdict(dict)
+            for ind in dr_inds:
+                flat_dr = ak.to_numpy(ak.flatten(qtys[f"{pre}Jet{ind}_radius"], axis=None))
+                flat_pt = ak.to_numpy(ak.flatten(qtys[f"{pre}Jet{ind}_pt"], axis=None))
+                sort_indices = np.argsort(flat_dr)
+                sorted_dr = flat_dr[sort_indices]
+                sorted_pt = flat_pt[sort_indices]
+                cumulative_pt = np.cumsum(sorted_pt)
+                total_pt = np.sum(sorted_pt)
+                for pct in dr_pcts:
+                    target_pt = pct/100 * total_pt
+                    index_pct = np.searchsorted(cumulative_pt, target_pt)
+                    r_pct_pt[ind][pct] = sorted_dr[index_pct]
+            for pct in dr_pcts:
+                print(f"{pct}% radius (pt-weighted):", ", ".join(["{:.2f}".format(r_pct_pt[ind][pct]) for ind in dr_inds]))
+
+            # also compute girth
+            for ind in [1,2]:
+                qtys[f"{pre}Jet{ind}_girth"] = calculate_girth(events[f"{pre}Jet{ind}"])
+            qtys[f"{pre}Jet_girth"] = ak.concatenate([qtys[f"{pre}Jet1_girth"], qtys[f"{pre}Jet2_girth"]])
+
+    # bind events into filling functions
+    def get_values(var,src):
+        return ak.flatten(src[var],axis=None)
+
+    def fill_hist(var,nbins,bmin,bmax,label,src=events):
         h = (
             hist.Hist.new
             .Reg(nbins, bmin, bmax, label=label)
             .Double()
         )
-        h.fill(get_values(var))
+        h.fill(get_values(var,src))
         return (var,h)
 
     # Creating hist objects
@@ -324,6 +380,18 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet2_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_2)$"),
             fill_hist("Jet1_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_1)$"),
             fill_hist("Jet2_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_2)$"),
+            fill_hist("DHJet1_radius",50,0,1,r"${\Delta}R(J_1^{\text{DH}})$",qtys),
+            fill_hist("DHJet2_radius",50,0,1,r"${\Delta}R(J_2^{\text{DH}})$",qtys),
+            fill_hist("DHJet_radius",50,0,1,r"${\Delta}R(J_{1,2}^{\text{DH}})$",qtys),
+            fill_hist("DHVJet1_radius",50,0,1,r"${\Delta}R(J_1^{\text{vis}})$",qtys),
+            fill_hist("DHVJet2_radius",50,0,1,r"${\Delta}R(J_2^{\text{vis}})$",qtys),
+            fill_hist("DHVJet_radius",50,0,1,r"${\Delta}R(J_{1,2}^{\text{vis}})$",qtys),
+            fill_hist("DHJet1_girth",50,0,1,r"$g_{\text{jet}}(J_1^{\text{DH}})$",qtys),
+            fill_hist("DHJet2_girth",50,0,1,r"$g_{\text{jet}}(J_2^{\text{DH}})$",qtys),
+            fill_hist("DHJet_girth",50,0,1,r"$g_{\text{jet}}(J_{1,2}^{\text{DH}})$",qtys),
+            fill_hist("DHVJet1_girth",50,0,1,r"$g_{\text{jet}}(J_1^{\text{vis}})$",qtys),
+            fill_hist("DHVJet2_girth",50,0,1,r"$g_{\text{jet}}(J_2^{\text{vis}})$",qtys),
+            fill_hist("DHVJet_girth",50,0,1,r"$g_{\text{jet}}(J_{1,2}^{\text{vis}})$",qtys),
         ])
     hist_dict.update([
         fill_hist("Jet1_sdmass",50,0,250,r"$m_{\text{SD}}(J_1)$ [GeV]"),
@@ -332,6 +400,9 @@ def histogram(filename, helper, with_constituents=True, debug=False):
         fill_hist("Jet2_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_2)$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
+        fill_hist("DHJet1_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_1^{\text{vis/DH}})$",qtys),
+        fill_hist("DHJet2_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_2^{\text{vis/DH}})$",qtys),
+        fill_hist("DHJet_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{1,2}^{\text{vis/DH}})$",qtys),
     ])
 
     for t in events.fields:

--- a/Histogram.py
+++ b/Histogram.py
@@ -184,7 +184,7 @@ def calc_rinv(events, helper, meta_dict, debug):
         stability = np.where(denom>0, numer/denom, 0)
     dprint('stability',stability.tolist())
     meta_dict["stability"] = fill_stats(stability)
-    print(f"Average computed rinv value = {meta_dict['stability']['mean']:.5} ({meta_dict['stability']['stdev']:.5})")
+    print(f"Average computed rinv value (pions) = {meta_dict['stability']['mean']:.5} ({meta_dict['stability']['stdev']:.5})")
 
     return stability
 
@@ -195,6 +195,9 @@ def calc_mt(jet, met):
     MTsq = (E1+E2)**2-(jet.px+met.px)**2-(jet.py+met.py)**2
     MTsq = MTsq.to_numpy(allow_missing=True)
     return np.sqrt(MTsq, where=MTsq>=0)
+
+def proj(events, jet, const):
+    return events[jet, const].dot(events[jet]) / events[jet].mag2
 
 def jet_const_cumsum(array):
     counts = ak.num(array, axis=-1)
@@ -223,6 +226,10 @@ def fill_stats(array):
 
 def histogram(filename, helper, with_constituents=True, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
+
+    # output dictionary with histograms and metadata
+    output = {}
+    output["model"] = helper.metadata()
     meta_dict = {}
 
     # require two jets
@@ -288,60 +295,79 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["mMediator"] = meds_final.mass
 
     # Add the invisible fraction to the events
+    print(f"Predicted rinv = {output['model'].get('rinv_3body',output['model'].get('rinv',-1)):.5}")
     events["stable_invisible_fraction"] = calc_rinv(events, helper, meta_dict, debug)
 
-    # dark hadron jets and corresponding visible jets
+    # dark hadron jets and corresponding visible and invisible+visible jets
     events["DHJet12"] = ak.pad_none(events.DarkHadronJet[:,0:2], target=2, axis=1)
     events["DHVJet12"] = ak.pad_none(events.DarkHadronVisibleJet[:,0:2], target=2, axis=1)
-
-    # per-jet calculation of invisible fraction based on pt
+    events["DHIVJet12"] = ak.pad_none(events.DarkHadronStableJet[:,0:2], target=2, axis=1)
+    dhj_pre = ["DH", "DHV", "DHIV"]
     jet_inds = [0, 1, slice(0, 2)]
     jet_ind_names = ["1","2","1,2"]
     jet_ind_keys = ["1","2","12"]
-    events["DHJet12_rinv"] = 1 - events["DHVJet12"].pt / events["DHJet12"].pt
-    for ind,key in zip(jet_inds, jet_ind_keys):
-        jrinv = events["DHJet12_rinv"][:, ind]
-        meta_dict[f"DHJet{key}_rinv"] = fill_stats(jrinv)
-    print("Average jet-level rinv =", ", ".join(
-        [f"{meta_dict[f'DHJet{key}_rinv']['mean']:.5} ({meta_dict[f'DHJet{key}_rinv']['stdev']:.5})" for key in jet_ind_keys]
-    ))
 
     if with_constituents:
-        events["DHJet12_nconst"] = ak.num(events["DHJet12"].Constituents, axis=-1)
-        events["DHVJet12_nconst"] = ak.num(events["DHVJet12"].Constituents, axis=-1)
+        # per-jet calculation of invisible fraction based on momentum projection
+        # pick out dark hadron constituents (stability already checked in Delphes)
+        dark_hadron_final_ids = helper.darkHadronFinalIDs
+        is_dark = ak.zeros_like(events["DHIVJet12"].Constituents.PID)
+        for dhid in dark_hadron_final_ids:
+            is_dark = is_dark | (np.abs(events["DHIVJet12"].Constituents.PID)==dhid)
+        is_dark = is_dark==1
+        events["DHIVJet12", "DHConstituents"] = events["DHIVJet12", "Constituents"][is_dark]
+        # project constituent momentum onto jet axis
+        proj_numer = proj(events, "DHIVJet12", "DHConstituents")
+        proj_denom = proj(events, "DHIVJet12", "Constituents")
+        events[f"DHIVJet12_rinv"] = ak.sum(proj_numer, axis=-1)/ak.sum(proj_denom, axis=-1)
+        for ind,key in zip(jet_inds, jet_ind_keys):
+            meta_dict[f"DHIVJet{key}_rinv"] = fill_stats(events[f"DHIVJet12_rinv"][:, ind])
+        print("Average jet-level rinv (p^inv.p^jet) =", ", ".join(
+            [f"{meta_dict[f'DHIVJet{key}_rinv']['mean']:.5} ({meta_dict[f'DHIVJet{key}_rinv']['stdev']:.5})" for key in jet_ind_keys]
+        ))
+        # summing jets
+        events["DiDHIVJet_rinv"] = ak.sum(ak.flatten(proj_numer, axis=2), axis=-1)/ak.sum(ak.flatten(proj_denom, axis=2), axis=-1)
+        meta_dict["DiDHIVJet_rinv"] = fill_stats(events["DiDHIVJet_rinv"])
+        print("Average dijet-level rinv (p^inv.p^jet) =",
+            f"{meta_dict['DiDHIVJet_rinv']['mean']:.5} ({meta_dict['DiDHIVJet_rinv']['stdev']:.5})"
+        )
+        # global version, summing all events
+        rinv_global = ak.sum(ak.flatten(proj_numer, axis=1))/ak.sum(ak.flatten(proj_denom, axis=1))
+        meta_dict[f"DHIVJet12_rinv_global"] = {"N": 1, "mean": rinv_global, "stdev": 0, "stderr": 0}
+        print("Global jet-level rinv (p^inv.p^jet) =",
+            f"{meta_dict['DHIVJet12_rinv_global']['mean']:.5}"
+        )
 
         # dark jet and visible jet radius
         dr_pcts = [90,95,99]
-        for pre in ["DH", "DHV"]:
+        for pre in dhj_pre:
             print(f"\n{pre}Jet")
+
+            # also compute nconst and girth
+            events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])
+            events[f"{pre}Jet12_nconst"] = ak.num(events[f"{pre}Jet12"].Constituents, axis=-1)
+
             # pt-weighted percentile per jet
             for pct in dr_pcts:
                 none_mask = ak.is_none(events[f"{pre}Jet12"], axis=1)
                 const_prop = ak.zip({
                     'dr': deltaR(events[f"{pre}Jet12"]),
-                    'px': events[f"{pre}Jet12"].Constituents.px,
-                    'py': events[f"{pre}Jet12"].Constituents.py,
+                    'proj': proj(events, f"{pre}Jet12", "Constituents"),
                 })[~none_mask]
                 sort_indices = ak.argsort(const_prop.dr, axis=-1)
                 sorted_prop = const_prop[sort_indices]
-                cumul_px = jet_const_cumsum(sorted_prop.px)
-                cumul_py = jet_const_cumsum(sorted_prop.py)
-                # running sum of pT within cone
-                cumul_pt = np.sqrt(cumul_px**2 + cumul_py**2)
-                # last element of sum is total pT from all constituents
-                total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
-                target_pt = pct/100 * total_pt
-                mask_pt = cumul_pt >= target_pt
-                events[f"{pre}Jet12_radius{pct}"] = ak.pad_none(ak.firsts(sorted_prop[mask_pt].dr, axis=-1), target=2, axis=1)
+                cumul_proj = jet_const_cumsum(sorted_prop.proj)
+                # last element of sum is total from all constituents
+                total_proj = ak.fill_none(ak.pad_none(cumul_proj, 1, axis=-1)[:, :, -1], 0)
+                target_proj = pct/100 * total_proj
+                mask_proj = cumul_proj >= target_proj
+                events[f"{pre}Jet12_radius{pct}"] = ak.pad_none(ak.firsts(sorted_prop[mask_proj].dr, axis=-1), target=2, axis=1)
                 for ind,key in zip(jet_inds, jet_ind_keys):
-                    r_pct_pt = events[f"{pre}Jet12_radius{pct}"][:, ind]
-                    meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_pt)
-                print(f"{pct}% radius (pt-weighted):", ", ".join(
+                    r_pct_proj = events[f"{pre}Jet12_radius{pct}"][:, ind]
+                    meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_proj)
+                print(f"{pct}% radius (p-weighted):", ", ".join(
                     [f"{meta_dict[f'DHJet{key}_radius{pct}']['mean']:.2} ({meta_dict[f'DHJet{key}_radius{pct}']['stdev']:.2})" for key in jet_ind_keys]
                 ))
-
-            # also compute girth
-            events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])
 
     # dark hadron jet mass and pt
     events["DHJet12_pt"] = events["DHJet12"].pt
@@ -352,6 +378,10 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["DiDHVJet"] = events["DHVJet12"][:,0] + events["DHVJet12"][:,1]
     events["DiDHVJet_mass"] = events["DiDHVJet"].mass
     events["DiDHVJet_MT"] = calc_mt(events["DiDHVJet"], events.GenMissingET)
+
+    events["DHIVJet12_pt"] = events["DHIVJet12"].pt
+    events["DiDHIVJet"] = events["DHIVJet12"][:,0] + events["DHIVJet12"][:,1]
+    events["DiDHIVJet_mass"] = events["DiDHIVJet"].mass
 
     # bind events into filling functions
     def fill_single_hist(var,nbins,bmin,bmax,label,ind=None):
@@ -399,28 +429,32 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
             fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
             fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
-            fill_hist("DHJet12_radius90",50,0,1,r"${\Delta}R_{90}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_radius90",50,0,1,r"${\Delta}R_{90}(J_{JETIND}^{\text{vis}})$"),
-            fill_hist("DHJet12_radius95",50,0,1,r"${\Delta}R_{95}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_radius95",50,0,1,r"${\Delta}R_{95}(J_{JETIND}^{\text{vis}})$"),
-            fill_hist("DHJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{vis}})$"),
-            fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
-            fill_hist("DHJet12_nconst",25,-0.5,24.5,r"$n_{\text{const}}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_nconst",50,-0.5,199.5,r"$n_{\text{const}}(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHIVJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{stable}})$"),
+            fill_hist("DiDHIVJet_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J^{\text{stable}}J^{\text{stable}})$"),
         ]))
+        dhj_labels = ["DH", "vis", "stable"]
+        dhj_nmax = [24.5, 199.5, 199.5]
+        dhj_nbin = [25, 50, 50]
+        for pre,label,nmax,nbin in zip(dhj_pre, dhj_labels,dhj_nmax,dhj_nbin):
+            hist_dict.update(chain.from_iterable([
+                fill_hist(f"{pre}Jet12_radius90",50,0,2,r"${\Delta}R_{90}(J_{JETIND}^{\text{"+label+"}})$"),
+                fill_hist(f"{pre}Jet12_radius95",50,0,2,r"${\Delta}R_{95}(J_{JETIND}^{\text{"+label+"}})$"),
+                fill_hist(f"{pre}Jet12_radius99",50,0,2,r"${\Delta}R_{99}(J_{JETIND}^{\text{"+label+"}})$"),
+                fill_hist(f"{pre}Jet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{"+label+"}})$"),
+                fill_hist(f"{pre}Jet12_nconst",nbin,-0.5,nmax,r"$n_{\text{const}}(J_{JETIND}^{\text{"+label+"}})$"),
+            ]))
     hist_dict.update(chain.from_iterable([
         fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
         fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
-        fill_hist("DHJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{vis/DH}})$"),
         fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
         fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
+        fill_hist("DHIVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{stable}})$ [GeV]"),
         fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{DH}}\text{J}^{\text{DH}}}$ [GeV]"),
         fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
         fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHIVJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{stable}}\text{J}^{\text{stable}}}$ [GeV]"),
     ]))
 
     for t in events.fields:
@@ -431,10 +465,8 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist(t,40,0,1,label)
         ]))
 
-    # output dictionary with histograms and metadata
-    output = {}
+    # finish output dictionary
     output["hist"] = hist_dict
-    output["model"] = helper.metadata()
     output["analysis"] = meta_dict
 
     # Saving the histograms

--- a/Histogram.py
+++ b/Histogram.py
@@ -7,6 +7,7 @@ from coffea.nanoevents import NanoEventsFactory
 from common import load_events
 from collections import defaultdict
 from itertools import chain
+from scipy.stats import sem
 
 def ET(vec):
     return np.sqrt(vec.px**2+vec.py**2+vec.mass**2)
@@ -182,8 +183,8 @@ def calc_rinv(events, helper, meta_dict, debug):
     with np.errstate(divide='ignore', invalid='ignore'):
         stability = np.where(denom>0, numer/denom, 0)
     dprint('stability',stability.tolist())
-    meta_dict["stability"] = (np.mean(stability), np.std(stability))
-    print(f"Average computed rinv value = {meta_dict['stability'][0]:.5} ({meta_dict['stability'][1]:.5})")
+    meta_dict["stability"] = fill_stats(stability)
+    print(f"Average computed rinv value = {meta_dict['stability']['mean']:.5} ({meta_dict['stability']['stdev']:.5})")
 
     return stability
 
@@ -210,6 +211,15 @@ def jet_const_cumsum(array):
     per_jet_flat = global_cumsum - subtractions
     jets_unflat = ak.unflatten(per_jet_flat, flat_counts)
     return ak.unflatten(jets_unflat, ak.num(counts, axis=1))
+
+def fill_stats(array):
+    nparray = ak.to_numpy(ak.flatten(array, axis=None))
+    return {
+        "N": len(nparray),
+        "mean": np.mean(nparray),
+        "stdev": np.std(nparray),
+        "stderr": sem(nparray),
+    }
 
 def histogram(filename, helper, with_constituents=True, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
@@ -291,9 +301,9 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["DHJet12_rinv"] = 1 - events["DHVJet12"].pt / events["DHJet12"].pt
     for ind,key in zip(jet_inds, jet_ind_keys):
         jrinv = events["DHJet12_rinv"][:, ind]
-        meta_dict[f"DHJet{key}_rinv"] = (np.mean(jrinv), np.std(jrinv))
+        meta_dict[f"DHJet{key}_rinv"] = fill_stats(jrinv)
     print("Average jet-level rinv =", ", ".join(
-        [f"{meta_dict[f'DHJet{key}_rinv'][0]:.5} ({meta_dict[f'DHJet{key}_rinv'][1]:.5})" for key in jet_ind_keys]
+        [f"{meta_dict[f'DHJet{key}_rinv']['mean']:.5} ({meta_dict[f'DHJet{key}_rinv']['stdev']:.5})" for key in jet_ind_keys]
     ))
 
     if with_constituents:
@@ -324,9 +334,9 @@ def histogram(filename, helper, with_constituents=True, debug=False):
                 events[f"{pre}Jet12_radius{pct}"] = ak.firsts(sorted_dr[mask_pt], axis=-1)
                 for ind,key in zip(jet_inds, jet_ind_keys):
                     r_pct_pt = events[f"{pre}Jet12_radius{pct}"][:, ind]
-                    meta_dict[f"DHJet{key}_radius{pct}"] = (np.mean(r_pct_pt), np.std(r_pct_pt))
+                    meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_pt)
                 print(f"{pct}% radius (pt-weighted):", ", ".join(
-                    [f"{meta_dict[f'DHJet{key}_radius{pct}'][0]:.2} ({meta_dict[f'DHJet{key}_radius{pct}'][1]:.2})" for key in jet_ind_keys]
+                    [f"{meta_dict[f'DHJet{key}_radius{pct}']['mean']:.2} ({meta_dict[f'DHJet{key}_radius{pct}']['stdev']:.2})" for key in jet_ind_keys]
                 ))
 
             # also compute girth

--- a/Histogram.py
+++ b/Histogram.py
@@ -316,27 +316,36 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             is_dark = is_dark | (np.abs(events["DHIVJet12"].Constituents.PID)==dhid)
         is_dark = is_dark==1
         events["DHIVJet12", "DHConstituents"] = events["DHIVJet12", "Constituents"][is_dark]
+
+        def fill_DHIVJet_rinv(numer, denom, suff):
+            events[f"DHIVJet12_rinv_{suff}"] = ak.sum(numer, axis=-1)/ak.sum(denom, axis=-1)
+            for ind,key in zip(jet_inds, jet_ind_keys):
+                meta_dict[f"DHIVJet{key}_rinv_{suff}"] = fill_stats(events[f"DHIVJet12_rinv_{suff}"][:, ind])
+            print(f"Average jet-level rinv ({suff}) =", ", ".join(
+                [f"{meta_dict[f'DHIVJet{key}_rinv_{suff}']['mean']:.5} ({meta_dict[f'DHIVJet{key}_rinv_{suff}']['stdev']:.5})" for key in jet_ind_keys]
+            ))
+            # summing jets
+            events[f"DiDHIVJet_rinv_{suff}"] = ak.sum(ak.flatten(numer, axis=2), axis=-1)/ak.sum(ak.flatten(denom, axis=2), axis=-1)
+            meta_dict[f"DiDHIVJet_rinv_{suff}"] = fill_stats(events[f"DiDHIVJet_rinv_{suff}"])
+            print(f"Average dijet-level rinv ({suff}) =",
+                f"{meta_dict[f'DiDHIVJet_rinv_{suff}']['mean']:.5} ({meta_dict[f'DiDHIVJet_rinv_{suff}']['stdev']:.5})"
+            )
+            # global version, summing all events
+            rinv_global = ak.sum(ak.flatten(numer, axis=1))/ak.sum(ak.flatten(denom, axis=1))
+            meta_dict[f"DHIVJet12_rinv_{suff}_global"] = {"N": 1, "mean": rinv_global, "stdev": 0, "stderr": 0}
+            print(f"Global jet-level rinv ({suff}) =",
+                f"{meta_dict[f'DHIVJet12_rinv_{suff}_global']['mean']:.5}"
+            )
+
         # project constituent momentum onto jet axis
         proj_numer = proj(events, "DHIVJet12", "DHConstituents")
         proj_denom = proj(events, "DHIVJet12", "Constituents")
-        events[f"DHIVJet12_rinv"] = ak.sum(proj_numer, axis=-1)/ak.sum(proj_denom, axis=-1)
-        for ind,key in zip(jet_inds, jet_ind_keys):
-            meta_dict[f"DHIVJet{key}_rinv"] = fill_stats(events[f"DHIVJet12_rinv"][:, ind])
-        print("Average jet-level rinv (p^inv.p^jet) =", ", ".join(
-            [f"{meta_dict[f'DHIVJet{key}_rinv']['mean']:.5} ({meta_dict[f'DHIVJet{key}_rinv']['stdev']:.5})" for key in jet_ind_keys]
-        ))
-        # summing jets
-        events["DiDHIVJet_rinv"] = ak.sum(ak.flatten(proj_numer, axis=2), axis=-1)/ak.sum(ak.flatten(proj_denom, axis=2), axis=-1)
-        meta_dict["DiDHIVJet_rinv"] = fill_stats(events["DiDHIVJet_rinv"])
-        print("Average dijet-level rinv (p^inv.p^jet) =",
-            f"{meta_dict['DiDHIVJet_rinv']['mean']:.5} ({meta_dict['DiDHIVJet_rinv']['stdev']:.5})"
-        )
-        # global version, summing all events
-        rinv_global = ak.sum(ak.flatten(proj_numer, axis=1))/ak.sum(ak.flatten(proj_denom, axis=1))
-        meta_dict[f"DHIVJet12_rinv_global"] = {"N": 1, "mean": rinv_global, "stdev": 0, "stderr": 0}
-        print("Global jet-level rinv (p^inv.p^jet) =",
-            f"{meta_dict['DHIVJet12_rinv_global']['mean']:.5}"
-        )
+        fill_DHIVJet_rinv(proj_numer, proj_denom, 'proj')
+
+        # alternative: use scalar pT sum (related to "jet shape" below)
+        shape_numer = events["DHIVJet12"].DHConstituents.pt
+        shape_denom = events["DHIVJet12"].Constituents.pt
+        fill_DHIVJet_rinv(shape_numer, shape_denom, 'shape')
 
         # dark jet and visible jet radius
         dr_pcts = [90,95,99]
@@ -348,24 +357,25 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             events[f"{pre}Jet12_nconst"] = ak.num(events[f"{pre}Jet12"].Constituents, axis=-1)
 
             # pt-weighted percentile per jet
+            # scalar sum of constituent pT within DeltaR / scalar sum of all constituent pT = "jet shape"
             for pct in dr_pcts:
                 none_mask = ak.is_none(events[f"{pre}Jet12"], axis=1)
                 const_prop = ak.zip({
                     'dr': deltaR(events[f"{pre}Jet12"]),
-                    'proj': proj(events, f"{pre}Jet12", "Constituents"),
+                    'pt': events[f"{pre}Jet12"].Constituents.pt,
                 })[~none_mask]
                 sort_indices = ak.argsort(const_prop.dr, axis=-1)
                 sorted_prop = const_prop[sort_indices]
-                cumul_proj = jet_const_cumsum(sorted_prop.proj)
+                cumul_pt = jet_const_cumsum(sorted_prop.pt)
                 # last element of sum is total from all constituents
-                total_proj = ak.fill_none(ak.pad_none(cumul_proj, 1, axis=-1)[:, :, -1], 0)
-                target_proj = pct/100 * total_proj
-                mask_proj = cumul_proj >= target_proj
-                events[f"{pre}Jet12_radius{pct}"] = ak.pad_none(ak.firsts(sorted_prop[mask_proj].dr, axis=-1), target=2, axis=1)
+                total_pt = ak.fill_none(ak.pad_none(cumul_pt, 1, axis=-1)[:, :, -1], 0)
+                target_pt = pct/100 * total_pt
+                mask_pt = cumul_pt >= target_pt
+                events[f"{pre}Jet12_radius{pct}"] = ak.pad_none(ak.firsts(sorted_prop[mask_pt].dr, axis=-1), target=2, axis=1)
                 for ind,key in zip(jet_inds, jet_ind_keys):
-                    r_pct_proj = events[f"{pre}Jet12_radius{pct}"][:, ind]
-                    meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_proj)
-                print(f"{pct}% radius (p-weighted):", ", ".join(
+                    r_pct_pt = events[f"{pre}Jet12_radius{pct}"][:, ind]
+                    meta_dict[f"DHJet{key}_radius{pct}"] = fill_stats(r_pct_pt)
+                print(f"{pct}% radius (jet shape):", ", ".join(
                     [f"{meta_dict[f'DHJet{key}_radius{pct}']['mean']:.2} ({meta_dict[f'DHJet{key}_radius{pct}']['stdev']:.2})" for key in jet_ind_keys]
                 ))
 
@@ -429,8 +439,10 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
             fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
             fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
-            fill_hist("DHIVJet12_rinv",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J_{JETIND}^{\text{stable}})$"),
-            fill_hist("DiDHIVJet_rinv",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J^{\text{stable}}J^{\text{stable}})$"),
+            fill_hist("DHIVJet12_rinv_proj",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J_{JETIND}^{\text{stable}})$"),
+            fill_hist("DiDHIVJet_rinv_proj",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J^{\text{stable}}J^{\text{stable}})$"),
+            fill_hist("DHIVJet12_rinv_shape",25,0,1,r"$r_{\text{inv}}^{\text{kin(alt)}}(J_{JETIND}^{\text{stable}})$"),
+            fill_hist("DiDHIVJet_rinv_shape",25,0,1,r"$r_{\text{inv}}^{\text{kin(alt)}}(J^{\text{stable}}J^{\text{stable}})$"),
         ]))
         dhj_labels = ["DH", "vis", "stable"]
         dhj_nmax = [24.5, 199.5, 199.5]

--- a/Histogram.py
+++ b/Histogram.py
@@ -290,6 +290,9 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     ))
 
     if with_constituents:
+        events["DHJet12_nconst"] = ak.num(events["DHJet12"].Constituents, axis=-1)
+        events["DHVJet12_nconst"] = ak.num(events["DHVJet12"].Constituents, axis=-1)
+
         # dark jet and visible jet radius
         dr_pcts = [90,95,99]
         for pre in ["DH", "DHV"]:
@@ -385,6 +388,8 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("DHVJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{vis}})$"),
             fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
             fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_nconst",25,0,25,r"$n_{\text{const}}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_nconst",50,0,200,r"$n_{\text{const}}(J_{JETIND}^{\text{vis}})$"),
         ]))
     hist_dict.update(chain.from_iterable([
         fill_hist("Jet12_sdmass",50,0,250,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),

--- a/Histogram.py
+++ b/Histogram.py
@@ -72,7 +72,7 @@ def getTau(events):
         if i != 1: events[f"Jet12_tau{i}{i-1}"] = events[f"Jet12_tau{i}"] / events[f"Jet12_tau{i-1}"]
     return events
 
-def calc_rinv(events, helper, debug):
+def calc_rinv(events, helper, meta_dict, debug):
     pid = events.GenParticle["PID"]
 
     def dprint(*args):
@@ -182,7 +182,8 @@ def calc_rinv(events, helper, debug):
     with np.errstate(divide='ignore', invalid='ignore'):
         stability = np.where(denom>0, numer/denom, 0)
     dprint('stability',stability.tolist())
-    print(f"Average computed rinv value = {np.mean(stability):.5} ({np.std(stability):.5})")
+    meta_dict["stability"] = (np.mean(stability), np.std(stability))
+    print(f"Average computed rinv value = {meta_dict['stability'][0]:.5} ({meta_dict['stability'][1]:.5})")
 
     return stability
 
@@ -212,6 +213,7 @@ def jet_const_cumsum(array):
 
 def histogram(filename, helper, with_constituents=True, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
+    meta_dict = {}
 
     # require two jets
     mask = ak.num(events.FatJet)>=2
@@ -276,7 +278,7 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["mMediator"] = meds_final.mass
 
     # Add the invisible fraction to the events
-    events["stable_invisible_fraction"] = calc_rinv(events, helper, debug)
+    events["stable_invisible_fraction"] = calc_rinv(events, helper, meta_dict, debug)
 
     # dark hadron jets and corresponding visible jets
     events["DHJet12"] = events.DarkHadronJet[:,0:2]
@@ -284,9 +286,14 @@ def histogram(filename, helper, with_constituents=True, debug=False):
 
     # per-jet calculation of invisible fraction based on pt
     jet_inds = [0, 1, slice(0, 2)]
+    jet_ind_names = ["1","2","1,2"]
+    jet_ind_keys = ["1","2","12"]
     events["DHJet12_rinv"] = 1 - events["DHVJet12"].pt / events["DHJet12"].pt
+    for ind,key in zip(jet_inds, jet_ind_keys):
+        jrinv = events["DHJet12_rinv"][:, ind]
+        meta_dict[f"DHJet{key}_rinv"] = (np.mean(jrinv), np.std(jrinv))
     print("Average jet-level rinv =", ", ".join(
-        [f"{np.mean(jrinv):.5} ({np.std(jrinv):.5})" for jrinv in [events["DHJet12_rinv"][:, ind] for ind in jet_inds]]
+        [f"{meta_dict[f'DHJet{key}_rinv'][0]:.5} ({meta_dict[f'DHJet{key}_rinv'][1]:.5})" for key in jet_ind_keys]
     ))
 
     if with_constituents:
@@ -315,8 +322,11 @@ def histogram(filename, helper, with_constituents=True, debug=False):
                 target_pt = pct/100 * total_pt
                 mask_pt = cumul_pt >= target_pt
                 events[f"{pre}Jet12_radius{pct}"] = ak.firsts(sorted_dr[mask_pt], axis=-1)
+                for ind,key in zip(jet_inds, jet_ind_keys):
+                    r_pct_pt = events[f"{pre}Jet12_radius{pct}"][:, ind]
+                    meta_dict[f"DHJet{key}_radius{pct}"] = (np.mean(r_pct_pt), np.std(r_pct_pt))
                 print(f"{pct}% radius (pt-weighted):", ", ".join(
-                    [f"{np.mean(r_pct_pt):.2} ({np.std(r_pct_pt):.2})" for r_pct_pt in [events[f"{pre}Jet12_radius{pct}"][:, ind] for ind in jet_inds]]
+                    [f"{meta_dict[f'DHJet{key}_radius{pct}'][0]:.2} ({meta_dict[f'DHJet{key}_radius{pct}'][1]:.2})" for key in jet_ind_keys]
                 ))
 
             # also compute girth
@@ -352,8 +362,6 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             return [(var,fill_single_hist(var,nbins,bmin,bmax,label))]
         else:
             results = []
-            jet_ind_names = ["1","2","1,2"]
-            jet_ind_keys = ["1","2","12"]
             for ind,key,name in zip(jet_inds, jet_ind_keys, jet_ind_names):
                 results.append((var.replace("Jet12",f"Jet{key}"), fill_single_hist(var,nbins,bmin,bmax,label.replace("JETIND",name),ind)))
             return results
@@ -412,6 +420,12 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist(t,40,0,1,label)
         ]))
 
+    # output dictionary with histograms and metadata
+    output = {}
+    output["hist"] = hist_dict
+    output["model"] = helper.metadata()
+    output["analysis"] = meta_dict
+
     # Saving the histograms
     with open("Hists.pkl", "wb") as out:
-        pickle.dump(hist_dict, out)
+        pickle.dump(output, out)

--- a/Histogram.py
+++ b/Histogram.py
@@ -181,12 +181,12 @@ def calc_rinv(events, helper, meta_dict, debug):
     numer = ak.sum(is_dark_final_daughter, axis=1).to_numpy()
     denom = ak.sum(is_dark_final, axis=1).to_numpy()
     with np.errstate(divide='ignore', invalid='ignore'):
-        stability = np.where(denom>0, numer/denom, 0)
-    dprint('stability',stability.tolist())
-    meta_dict["stability"] = fill_stats(stability)
-    print(f"Average computed rinv value (pions) = {meta_dict['stability']['mean']:.5} ({meta_dict['stability']['stdev']:.5})")
+        stable_invisible_fraction = np.where(denom>0, numer/denom, 0)
+    dprint('stable_invisible_fraction',stable_invisible_fraction.tolist())
+    meta_dict["stable_invisible_fraction"] = fill_stats(stable_invisible_fraction)
+    print(f"Average computed rinv value (pions) = {meta_dict['stable_invisible_fraction']['mean']:.5} ({meta_dict['stable_invisible_fraction']['stdev']:.5})")
 
-    return stability
+    return stable_invisible_fraction
 
 def calc_mt(jet, met):
     # transverse mass calculation

--- a/Histogram.py
+++ b/Histogram.py
@@ -429,8 +429,8 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
             fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
             fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
-            fill_hist("DHIVJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{stable}})$"),
-            fill_hist("DiDHIVJet_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J^{\text{stable}}J^{\text{stable}})$"),
+            fill_hist("DHIVJet12_rinv",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J_{JETIND}^{\text{stable}})$"),
+            fill_hist("DiDHIVJet_rinv",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J^{\text{stable}}J^{\text{stable}})$"),
         ]))
         dhj_labels = ["DH", "vis", "stable"]
         dhj_nmax = [24.5, 199.5, 199.5]
@@ -446,15 +446,15 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     hist_dict.update(chain.from_iterable([
         fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
         fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
-        fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
+        fill_hist("stable_invisible_fraction",25,0,1,r"$r_{\text{inv}}^{\text{gen}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
         fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
         fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
         fill_hist("DHIVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{stable}})$ [GeV]"),
-        fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{DH}}\text{J}^{\text{DH}}}$ [GeV]"),
-        fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
-        fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
-        fill_hist("DiDHIVJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{stable}}\text{J}^{\text{stable}}}$ [GeV]"),
+        fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{DH}}J^{\text{DH}}}$ [GeV]"),
+        fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHIVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{stable}}J^{\text{stable}}}$ [GeV]"),
     ]))
 
     for t in events.fields:

--- a/Histogram.py
+++ b/Histogram.py
@@ -216,7 +216,7 @@ def jet_const_cumsum(array):
     return ak.unflatten(jets_unflat, ak.num(counts, axis=1))
 
 def fill_stats(array):
-    nparray = ak.to_numpy(ak.flatten(array, axis=None))
+    nparray = ak.to_numpy(ak.drop_none(ak.nan_to_none(ak.flatten(array, axis=None))))
     return {
         "N": len(nparray),
         "mean": np.mean(nparray),

--- a/Histogram.py
+++ b/Histogram.py
@@ -402,8 +402,10 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     for t in events.fields:
         if 'tau' not in t: continue
         l = t.split('_')
-        label = l[1].replace('tau', '$\\tau_{')+','+l[0].replace('et', '_')+'}$'
-        hist_dict[t] = fill_hist(t,40,0,1,label)
+        label = l[1].replace('tau', '$\\tau_{')+','+l[0].replace('et12', '_{JETIND}')+'}$'
+        hist_dict.update(chain.from_iterable([
+            fill_hist(t,40,0,1,label)
+        ]))
 
     # Saving the histograms
     with open("Hists.pkl", "wb") as out:

--- a/Histogram.py
+++ b/Histogram.py
@@ -186,6 +186,14 @@ def calc_rinv(events, helper, debug):
 
     return stability
 
+def calc_mt(jet, met):
+    # transverse mass calculation
+    E1 = ET(jet)
+    E2 = met.MET
+    MTsq = (E1+E2)**2-(jet.px+met.px)**2-(jet.py+met.py)**2
+    MTsq = MTsq.to_numpy(allow_missing=True)
+    return np.sqrt(MTsq, where=MTsq>=0)
+
 def histogram(filename, helper, with_constituents=True, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
 
@@ -201,11 +209,7 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["Dijet"] = events.FatJet[:,0]+events.FatJet[:,1]
 
     # transverse mass calculation
-    E1 = ET(events.Dijet)
-    E2 = events.MissingET.MET
-    MTsq = (E1+E2)**2-(events.Dijet.px+events.MissingET.px)**2-(events.Dijet.py+events.MissingET.py)**2
-    MTsq = MTsq.to_numpy(allow_missing=True)
-    events["MT"] = np.sqrt(MTsq, where=MTsq>=0)
+    events["MT"] = calc_mt(events.Dijet, events.MissingET)
 
     # 4-vectors for dijet
     events["Dijet_pt"] = events.Dijet.pt
@@ -301,6 +305,16 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             # also compute girth
             events[f"{pre}Jet12_girth"] = calculate_girth(events[f"{pre}Jet12"])
 
+    # dark hadron jet mass and pt
+    events["DHJet12_pt"] = events["DHJet12"].pt
+    events["DiDHJet"] = events.DarkHadronJet[:,0] + events.DarkHadronJet[:,1]
+    events["DiDHJet_mass"] = events["DiDHJet"].mass
+
+    events["DHVJet12_pt"] = events["DHVJet12"].pt
+    events["DiDHVJet"] = events.DarkHadronVisibleJet[:,0] + events.DarkHadronVisibleJet[:,1]
+    events["DiDHVJet_mass"] = events["DiDHVJet"].mass
+    events["DiDHVJet_MT"] = calc_mt(events["DiDHVJet"], events.GenMissingET)
+
     # bind events into filling functions
     def fill_single_hist(var,nbins,bmin,bmax,label,ind=None):
         h = (
@@ -360,6 +374,11 @@ def histogram(filename, helper, with_constituents=True, debug=False):
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
         fill_hist("DHJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{vis/DH}})$"),
+        fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
+        fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
+        fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{DH}}\text{J}^{\text{DH}}}$ [GeV]"),
+        fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{\text{J}^{\text{vis}}\text{J}^{\text{vis}}}$ [GeV]"),
     ]))
 
     for t in events.fields:

--- a/Histogram.py
+++ b/Histogram.py
@@ -495,6 +495,14 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     output["hist"] = hist_dict
     output["analysis"] = meta_dict
 
+    # alternative 3body rinv calculation using alpha measured from Pythia
+    if helper.mrho < 2*helper.mpi:
+        from svjHelper import fcdc_rinv_3body, fcdc_rinv_3body_simp
+        if helper.Ns is not None:
+            output["model"]['rinv_3body_gen'] = fcdc_rinv_3body(Nf=helper.Nf, Ns=helper.Ns, mrho=helper.mrho, mpi=helper.mpi, pvector=helper.pvector, alpha=meta_dict['alpha_3body']['mean'])
+        else:
+            output["model"]['rinv_3body_gen'] = fcdc_rinv_3body_simp(rinv=helper.rinv, Nf=helper.Nf, mrho=helper.mrho, mpi=helper.mpi, pvector=helper.pvector, alpha=meta_dict['alpha_3body']['mean'])
+
     # Saving the histograms
     with open("Hists.pkl", "wb") as out:
         pickle.dump(output, out)

--- a/Histogram.py
+++ b/Histogram.py
@@ -11,16 +11,8 @@ from itertools import chain
 def ET(vec):
     return np.sqrt(vec.px**2+vec.py**2+vec.mass**2)
 
-def normalize_angle(angle):
-    angle = np.mod(angle, 2 * np.pi)
-    angle = np.where(angle >= np.pi, angle - 2 * np.pi, angle)
-    return angle
-
 def deltaR(jet):
-    deta_particle = np.abs(jet.eta-jet.Constituents.eta)
-    dphi_particle = np.abs(normalize_angle(jet.phi-jet.Constituents.phi))
-    dR = np.sqrt(deta_particle**2+dphi_particle**2)
-    return dR
+    return jet.deltaR(jet.Constituents)
 
 def calculate_girth(jet):
     particle_dR = deltaR(jet)
@@ -39,7 +31,7 @@ def calculate_ptD(jet):
 def calc_axis1_axis2(jet):
     jet_constpt = jet.Constituents.pt
     deta_particle = np.abs(jet.eta-jet.Constituents.eta)
-    dphi_particle = np.abs(normalize_angle(jet.phi-jet.Constituents.phi))
+    dphi_particle = np.abs(jet.deltaphi(jet.Constituents))
 
     # Calculate weights (pt^2) for each constituent
     weights_pt = jet_constpt**2
@@ -74,11 +66,10 @@ def calc_axis1_axis2(jet):
     return axis1, axis2
 
 def getTau(events):
-    for j in ['Jet1', 'Jet2']:
-        # we have tau1 to tau5
-        for i in range(1,6):
-            events[j+'_tau{:d}'.format(i)] = events[j].Tau_5[:,i-1]
-            if i != 1: events[j+'_tau{:d}{:d}'.format(i, i-1)] = events[j+'_tau{:d}'.format(i)] / events[j+'_tau{:d}'.format(i-1)]
+    # we have tau1 to tau5
+    for i in range(1,6):
+        events[f"Jet12_tau{i}"] = events["Jet12"].Tau_5[:,:,i-1]
+        if i != 1: events[f"Jet12_tau{i}{i-1}"] = events[f"Jet12_tau{i}"] / events[f"Jet12_tau{i-1}"]
     return events
 
 def calc_rinv(events, helper, debug):
@@ -225,41 +216,26 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     events["MET"] = events.MissingET.MET
 
     ## For plotting individually for jet1 and jet2
-
-    events["Jet1"] = events.FatJet[:,0]
-    events["Jet2"] = events.FatJet[:,1]
+    events["Jet12"] = events.FatJet[:,0:2]
 
     # 4-vectors for jet1 and jet2
-    events["Jet1_pt"] = events["Jet1"].pt
-    events["Jet2_pt"] = events["Jet2"].pt
+    events["Jet12_pt"] = events["Jet12"].pt
+    events["Jet12_eta"] = events["Jet12"].eta
+    events["Jet12_phi"] = events["Jet12"].phi
+    events["Jet12_mass"] = events["Jet12"].mass
 
-    events["Jet1_eta"] = events["Jet1"].eta
-    events["Jet2_eta"] = events["Jet2"].eta
+    events["DeltaEta"] = np.abs(events["Jet12_eta"][:,0] - events["Jet12_eta"][:,1])
+    events["DeltaPhi"] = np.abs(events["Jet12"][:,0].deltaphi(events["Jet12"][:,1]))
 
-    events["Jet1_phi"] = events["Jet1"].phi
-    events["Jet2_phi"] = events["Jet2"].phi
-
-    events["Jet1_mass"] = events["Jet1"].mass
-    events["Jet2_mass"] = events["Jet2"].mass
-
-    events["DeltaEta"] = np.abs(events["Jet2_eta"] - events["Jet1_eta"])
-    events["DeltaPhi"] = np.abs(normalize_angle(events["Jet1_phi"] - events["Jet2_phi"]))
-
-    events["DeltaPhi_MET_Jet1"] = np.abs(normalize_angle(events.MissingET.phi - events["Jet1_phi"]))
-    events["DeltaPhi_MET_Jet2"] = np.abs(normalize_angle(events.MissingET.phi - events["Jet2_phi"]))
+    events["DeltaPhi_MET_Jet12"] = np.abs(events.MissingET.deltaphi(events["Jet12"]))
 
     # add substructure quantities
     if with_constituents:
-        events["Jet1_girth"] = calculate_girth(events["Jet1"])
-        events["Jet2_girth"] = calculate_girth(events["Jet2"])
-        events["Jet1_ptD"] = calculate_ptD(events["Jet1"])
-        events["Jet2_ptD"] = calculate_ptD(events["Jet2"])
-        events["Jet1_majoraxis"], events["Jet1_minoraxis"] = calc_axis1_axis2(events["Jet1"])
-        events["Jet2_majoraxis"], events["Jet2_minoraxis"] = calc_axis1_axis2(events["Jet2"])
-    events["Jet1_sdmass"] = events["Jet1"].SoftDroppedJet.mass
-    events["Jet2_sdmass"] = events["Jet2"].SoftDroppedJet.mass
-    events["Jet1_sdpt"] = events["Jet1"].SoftDroppedJet.pt
-    events["Jet2_sdpt"] = events["Jet2"].SoftDroppedJet.pt
+        events["Jet12_girth"] = calculate_girth(events["Jet12"])
+        events["Jet12_ptD"] = calculate_ptD(events["Jet12"])
+        events["Jet12_majoraxis"], events["Jet12_minoraxis"] = calc_axis1_axis2(events["Jet12"])
+    events["Jet12_sdmass"] = events["Jet12"].SoftDroppedJet.mass
+    events["Jet12_sdpt"] = events["Jet12"].SoftDroppedJet.pt
 
     events = getTau(events)
 
@@ -358,40 +334,29 @@ def histogram(filename, helper, with_constituents=True, debug=False):
         fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
         fill_hist("Dijet_phi",25,-3.15,3.15,r"$\phi(JJ)$"),
         fill_hist("Dijet_mass",50,0,mmed*1.5,r"$m_{JJ}$ [GeV]"),
-        fill_hist("Jet1_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_1)$ [GeV]"),
-        fill_hist("Jet2_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_2)$ [GeV]"),
-        fill_hist("Jet1_eta",50,-6,6,r"$\eta(J_1)$"),
-        fill_hist("Jet2_eta",50,-6,6,r"$\eta(J_2)$"),
-        fill_hist("Jet1_phi",25,-3.15,3.15,r"$\phi(J_1)$"),
-        fill_hist("Jet2_phi",25,-3.15,3.15,r"$\phi(J_2)$"),
-        fill_hist("Jet1_mass",50,0,250,r"$m_{J_1}$ [GeV]"),
-        fill_hist("Jet2_mass",50,0,250,r"$m_{J_2}$ [GeV]"),
+        fill_hist("Jet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND})$ [GeV]"),
+        fill_hist("Jet12_eta",50,-6,6,r"$\eta(J_{JETIND})$"),
+        fill_hist("Jet12_phi",25,-3.15,3.15,r"$\phi(J_{JETIND})$"),
+        fill_hist("Jet12_mass",50,0,250,r"$m_{J_{JETIND}}$ [GeV]"),
         fill_hist("MET",50,0,mmed*0.75,r"$p_{\text{T}}^{\text{miss}}$ [GeV]"),
         fill_hist("DeltaEta",35,0,8.0,r"$\Delta\eta(JJ)$"),
         fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
-        fill_hist("DeltaPhi_MET_Jet1",25,0,3.15,r"$\Delta\phi(J_1,p_{\text{T}}^{\text{miss}})$"),
-        fill_hist("DeltaPhi_MET_Jet2",25,0,3.15,r"$\Delta\phi(J_2,p_{\text{T}}^{\text{miss}})$"),
+        fill_hist("DeltaPhi_MET_Jet12",25,0,3.15,r"$\Delta\phi(J_{JETIND},p_{\text{T}}^{\text{miss}})$"),
     ]))
     if with_constituents:
         hist_dict.update(chain.from_iterable([
-            fill_hist("Jet1_girth",50,0,1,r"$g_{\text{jet}}(J_1)$"),
-            fill_hist("Jet2_girth",50,0,1,r"$g_{\text{jet}}(J_2)$"),
-            fill_hist("Jet1_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_1)$"),
-            fill_hist("Jet2_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_2)$"),
-            fill_hist("Jet1_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_1)$"),
-            fill_hist("Jet2_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_2)$"),
-            fill_hist("Jet1_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_1)$"),
-            fill_hist("Jet2_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_2)$"),
+            fill_hist("Jet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND})$"),
+            fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
+            fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
+            fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
             fill_hist("DHJet12_radius",50,0,1,r"${\Delta}R(J_{JETIND}^{\text{DH}})$"),
             fill_hist("DHVJet12_radius",50,0,3,r"${\Delta}R(J_{JETIND}^{\text{vis}})$"),
             fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
             fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
         ]))
     hist_dict.update(chain.from_iterable([
-        fill_hist("Jet1_sdmass",50,0,250,r"$m_{\text{SD}}(J_1)$ [GeV]"),
-        fill_hist("Jet2_sdmass",50,0,250,r"$m_{\text{SD}}(J_2)$ [GeV]"),
-        fill_hist("Jet1_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_1)$ [GeV]"),
-        fill_hist("Jet2_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_2)$ [GeV]"),
+        fill_hist("Jet12_sdmass",50,0,250,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
+        fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
         fill_hist("DHJet12_rinv",25,0,1,r"$\widetilde{r}_{\text{inv}}(J_{JETIND}^{\text{vis/DH}})$"),

--- a/Histogram.py
+++ b/Histogram.py
@@ -407,11 +407,11 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             fill_hist("DHVJet12_radius99",50,0,1,r"${\Delta}R_{99}(J_{JETIND}^{\text{vis}})$"),
             fill_hist("DHJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{DH}})$"),
             fill_hist("DHVJet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{vis}})$"),
-            fill_hist("DHJet12_nconst",25,0,25,r"$n_{\text{const}}(J_{JETIND}^{\text{DH}})$"),
-            fill_hist("DHVJet12_nconst",50,0,200,r"$n_{\text{const}}(J_{JETIND}^{\text{vis}})$"),
+            fill_hist("DHJet12_nconst",25,-0.5,24.5,r"$n_{\text{const}}(J_{JETIND}^{\text{DH}})$"),
+            fill_hist("DHVJet12_nconst",50,-0.5,199.5,r"$n_{\text{const}}(J_{JETIND}^{\text{vis}})$"),
         ]))
     hist_dict.update(chain.from_iterable([
-        fill_hist("Jet12_sdmass",50,0,250,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
+        fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
         fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
         fill_hist("stable_invisible_fraction",25,0,1,r"$\overline{r}_{\text{inv}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -89,7 +89,7 @@ def make_all_plots(outdir, sample_list, x, y, offset):
         stat_plot(data, x, qname, outdir, offset)
 
 if __name__=="__main__":
-    qtys_default = ['stability','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
+    qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
 
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -73,15 +73,19 @@ def process_data(data, x, qname, forcex):
     return processed
 
 # helper to make a plot
-def make_plot(type, data, x, qname, outdir, offset):
+def make_plot(type, data, x, xlabel, qname, outdir, offset):
     fig, ax = plt.subplots(figsize=(8,6))
     # iterator for manual control
     props = iter(custom_cycler)
     # advance iterator if requested
     next(itertools.islice(props, offset, offset), None)
     ylim = None
+    ylabel = None
     if type=='stat':
         for entry in data:
+            # extract label
+            if ylabel is None and len(entry['hists'])>0:
+                ylabel = entry['hists'][0].axes[0].label
             style = next(props)
             # means
             line, = ax.plot(entry['xvals'], entry['means'], label=entry['sample'], fillstyle='none', **style)
@@ -106,6 +110,7 @@ def make_plot(type, data, x, qname, outdir, offset):
             if len(labels)==0:
                 labels = entry['xvals']
                 bin_edges = entry['hists'][0].axes[0].edges
+                ylabel = entry['hists'][0].axes[0].label
                 ylim = (bin_edges[0], bin_edges[-1])
                 heights = np.diff(bin_edges)
                 centers = bin_edges[:-1] + heights/2
@@ -137,14 +142,16 @@ def make_plot(type, data, x, qname, outdir, offset):
             ax.set_xticks(x_locs, [f'{label:.3f}' for label in labels], rotation=45)
     if type=='stat':
         ax.axline((0,0), slope=1, color='black', linestyle=':')
-    ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')
+    if xlabel is None: xlabel = x
+    ax.set_xlabel(xlabel)
     if ylim: ax.set_ylim(*ylim)
-    ax.set_ylabel(qname)
+    if ylabel is None: ylabel = qname
+    ax.set_ylabel(ylabel)
     ax.legend(framealpha=0.5)
     plt.savefig(f'{outdir}/{type}_{qname}.pdf',bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir, types, sample_list, x, y, forcex, offset):
+def make_all_plots(outdir, types, sample_list, x, y, xlabel, forcex, offset):
     data = {} # hists + metadata for all models
 
     for sample in samples:
@@ -166,11 +173,11 @@ def make_all_plots(outdir, types, sample_list, x, y, forcex, offset):
     for qname in y:
         processed = process_data(data, x, qname, forcex)
         for plot_type in types:
-            make_plot(plot_type, processed, x, qname, outdir, offset)
+            make_plot(plot_type, processed, x, xlabel, qname, outdir, offset)
 
 if __name__=="__main__":
     allowed_types = ['stat', 'violin']
-    qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
+    qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv_proj','DiDHIVJet_rinv_proj','DHIVJet12_rinv_proj_global']
 
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
@@ -179,6 +186,7 @@ if __name__=="__main__":
     parser.add_argument("--types", type=str, default=allowed_types, nargs='*', choices=allowed_types, help="plot types")
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
     parser.add_argument("-x", type=str, default='rinv', help="x variable")
+    parser.add_argument("--xlabel", type=str, default=None, help="x axis label")
     parser.add_argument("--forcex", type=str, default=None, help="force use of x values from specified sample")
     parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")
     parser.add_argument("--offset", type=int, default=0, help="offset for color/style cycler")
@@ -188,4 +196,4 @@ if __name__=="__main__":
     if unknown_samples:
         raise ValueError("Unknown sample(s) requested:",','.join(unknown_samples))
 
-    make_all_plots(args.dir, args.types, args.samples, args.x, args.y, args.forcex, args.offset)
+    make_all_plots(args.dir, args.types, args.samples, args.x, args.y, args.xlabel, args.forcex, args.offset)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -86,13 +86,15 @@ def make_all_plots(outdir, sample_list, x, y):
         stat_plot(data, x, qname, outdir)
 
 if __name__=="__main__":
+    qtys_default = ['stability','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
+
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
     )
     parser.add_argument("--dir", type=str, default="All_metaplots", help="output directory")
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
     parser.add_argument("-x", type=str, default='rinv', help="x variable")
-    parser.add_argument("-y", type=str, default=['stability','DHJet12_rinv'], nargs='*', help="y variable(s)")
+    parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")
     args = parser.parse_args()
 
     unknown_samples = [s for s in args.samples if not any([s==sm['name'] for sm in samples])]

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -122,7 +122,7 @@ def make_plot(type, data, x, qname, outdir, offset):
                 ax.barh(centers, hist, height=heights, left=lefts, **style)
                 # only apply label once
                 style.pop('label', None)
-            ax.set_xticks(x_locs, labels)
+            ax.set_xticks(x_locs, [f'{label:.3f}' for label in labels], rotation=45)
     if type=='stat':
         ax.axline((0,0), slope=1, color='black', linestyle=':')
     ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -1,0 +1,90 @@
+import os
+import hist
+import numpy as np
+import matplotlib as mpl
+mpl.use('Agg')
+import matplotlib.pyplot as plt
+import mplhep as hep
+import pickle
+from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
+from glob import glob
+
+samples = [
+	{"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+	{"name": "simp", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+	{"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+	{"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+]
+
+# stylistic options
+mpl.rcParams.update({
+    "axes.labelsize" : 18,
+    "legend.fontsize" : 16,
+    "xtick.labelsize" : 14,
+    "ytick.labelsize" : 14,
+    "font.size" : 18,
+    "legend.frameon": True,
+})
+# based on https://github.com/mpetroff/accessible-color-cycles
+# red, blue, mauve, orange, purple, gray,
+colors = ["#e42536", "#5790fc", "#964a8b", "#f89c20", "#7a21dd", "#9c9ca1"]
+
+# last two are dashdotdot and dashdashdot
+lines = ["solid", "dashed", "dotted", "dashdot", (0, (3, 5, 1, 5, 1, 5)), (0, (3, 5, 3, 5, 1, 5))]
+custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines)
+
+data = {} # hists + metadata for all models
+
+for sample in samples:
+    data[sample["name"]] = []
+    for model in sample['models']:
+        file = f'{model}/Hists.pkl'
+
+        with open(file, "rb") as inp:
+            data_model = pickle.load(inp)
+
+        data[sample["name"]].append(data_model)
+
+# helper to make a plot
+def stat_plot(qname, outdir):
+    fig, ax = plt.subplots(figsize=(8,6))
+    # iterator for manual control
+    props = iter(custom_cycler)
+    for sample, models in data.items():
+        style = next(props)
+        xvals = np.array([model['model']['rinv_fcdc'] if 'rinv_fcdc' in model['model'] else model['model']['rinv'] for model in models])
+        means, stdevs, stderrs = zip(*[
+            (model['analysis'][qname]['mean'], model['analysis'][qname]['stdev'], model['analysis'][qname]['stderr']) for model in models
+        ])
+        # order by rinv_pred
+        order = np.argsort(xvals)
+        xvals = xvals[order]
+        means = np.array(means)[order]
+        stdevs = np.array(stdevs)[order]
+        stderrs = np.array(stderrs)[order]
+        # means
+        line, = ax.plot(xvals, means, 'o-', label=sample, **style)
+        color = line.get_color()
+        # stderr as errorbar
+        ax.errorbar(xvals, means, yerr=stderrs, fmt='none', ecolor=style['color'], capsize=3, **style)
+        # stdev as filled
+        ax.fill_between(xvals, means-stdevs, means+stdevs, color=style['color'], alpha=0.15)
+    ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')
+    ax.set_ylabel(qname)
+    ax.legend(framealpha=0.5)
+    plt.savefig('{}/stat_{}.pdf'.format(outdir,qname),bbox_inches='tight')
+    plt.close(fig)
+
+def make_all_plots(outdir):
+    os.makedirs(outdir, exist_ok=True)
+    for qname in ['stability','DHJet12_rinv']:
+        stat_plot(qname, outdir)
+
+if __name__=="__main__":
+    parser = ArgumentParser(
+        formatter_class=ArgumentDefaultsRawHelpFormatter
+    )
+    parser.add_argument("--dir", type=str, default="All_metaplots", help="output directory")
+    args = parser.parse_args()
+
+    make_all_plots(args.dir)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -40,7 +40,7 @@ def process_data(data, x, qname):
     for sample, models in data.items():
         xvals = np.array([model['meta'][x] for model in models])
         means, stdevs, stderrs, hists = zip(*[
-            (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr'], model['hist'][qname]) for model in models
+            (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr'], model['hist'].get(qname,None)) for model in models
         ])
         # order by rinv_pred
         order = np.argsort(xvals)
@@ -52,6 +52,11 @@ def process_data(data, x, qname):
             stderrs = np.array(stderrs)[order],
             hists = [hists[i] for i in order],
         )
+        hists_missing = [h is None for h in processed_dict['hists']]
+        if all(hists_missing):
+            processed_dict['hists'] = []
+        elif any(hists_missing):
+            raise RuntimeError(f"Missing histogram {qname} in:\n"+','.join([model[file] for i,model in enumerate(models) if hists_missing[i]]))
         processed.append(processed_dict)
     return processed
 
@@ -62,6 +67,7 @@ def make_plot(type, data, x, qname, outdir, offset):
     props = iter(custom_cycler)
     # advance iterator if requested
     next(itertools.islice(props, offset, offset), None)
+    ylim = None
     for entry in data:
         style = next(props)
         if type=='stat':
@@ -72,10 +78,14 @@ def make_plot(type, data, x, qname, outdir, offset):
             # stdev as filled
             ax.fill_between(entry['xvals'], entry['means']-entry['stdevs'], entry['means']+entry['stdevs'], color=style['color'], alpha=0.15)
         elif type=='violin':
+            if len(entry['hists'])==0:
+                continue
+
             # extract values from histograms
             hists = [h.values() for h in entry['hists']]
-            bin_edges = entry['hists'][0].axes[0].edges
             labels = entry['xvals']
+            bin_edges = entry['hists'][0].axes[0].edges
+            ylim = (bin_edges[0], bin_edges[-1])
 
             # compute quantities for plotting
             binned_maxs = np.max(hists, axis=1)
@@ -87,15 +97,19 @@ def make_plot(type, data, x, qname, outdir, offset):
             style.update({
                 'fc': 'none',
                 'ec': style['color'],
+                'label': entry['sample']
             })
             style.pop('marker')
             for x_loc, hist in zip(x_locs, hists):
                 lefts = x_loc - 0.5 * hist
                 ax.barh(centers, hist, height=heights, left=lefts, **style)
+                # only apply label once
+                style.pop('label', None)
             ax.set_xticks(x_locs, labels)
     if type=='stat':
         ax.axline((0,0), slope=1, color='black', linestyle=':')
     ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')
+    if ylim: ax.set_ylim(*ylim)
     ax.set_ylabel(qname)
     ax.legend(framealpha=0.5)
     plt.savefig(f'{outdir}/{type}_{qname}.pdf',bbox_inches='tight')
@@ -112,6 +126,8 @@ def make_all_plots(outdir, sample_list, x, y, offset):
 
             with open(file, "rb") as inp:
                 data_model = pickle.load(inp)
+                # track filename
+                data_model['file'] = file
                 # join these for ease of use
                 data_model['meta'] = data_model['model'] | data_model['analysis']
 

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -52,7 +52,7 @@ def stat_plot(qname, outdir):
     props = iter(custom_cycler)
     for sample, models in data.items():
         style = next(props)
-        xvals = np.array([model['model']['rinv_fcdc'] if 'rinv_fcdc' in model['model'] else model['model']['rinv'] for model in models])
+        xvals = np.array([model['model']['rinv'] for model in models])
         means, stdevs, stderrs = zip(*[
             (model['analysis'][qname]['mean'], model['analysis'][qname]['stdev'], model['analysis'][qname]['stderr']) for model in models
         ])

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -8,6 +8,7 @@ import mplhep as hep
 import pickle
 from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 from glob import glob
+import itertools
 
 samples = [
     {"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
@@ -35,10 +36,12 @@ markers = ['o', 's', 'D', 'v', '^', '*']
 custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines) + mpl.cycler(marker=markers)
 
 # helper to make a plot
-def stat_plot(data, x, qname, outdir):
+def stat_plot(data, x, qname, outdir, offset):
     fig, ax = plt.subplots(figsize=(8,6))
     # iterator for manual control
     props = iter(custom_cycler)
+    # advance iterator if requested
+    next(itertools.islice(props, offset, offset), None)
     for sample, models in data.items():
         style = next(props)
         xvals = np.array([model['meta'][x] for model in models])
@@ -65,7 +68,7 @@ def stat_plot(data, x, qname, outdir):
     plt.savefig('{}/stat_{}.pdf'.format(outdir,qname),bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir, sample_list, x, y):
+def make_all_plots(outdir, sample_list, x, y, offset):
     data = {} # hists + metadata for all models
 
     for sample in samples:
@@ -83,7 +86,7 @@ def make_all_plots(outdir, sample_list, x, y):
 
     os.makedirs(outdir, exist_ok=True)
     for qname in y:
-        stat_plot(data, x, qname, outdir)
+        stat_plot(data, x, qname, outdir, offset)
 
 if __name__=="__main__":
     qtys_default = ['stability','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
@@ -95,10 +98,11 @@ if __name__=="__main__":
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
     parser.add_argument("-x", type=str, default='rinv', help="x variable")
     parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")
+    parser.add_argument("--offset", type=int, default=0, help="offset for color/style cycler")
     args = parser.parse_args()
 
     unknown_samples = [s for s in args.samples if not any([s==sm['name'] for sm in samples])]
     if unknown_samples:
         raise ValueError("Unknown sample(s) requested:",','.join(unknown_samples))
 
-    make_all_plots(args.dir, args.samples, args.x, args.y)
+    make_all_plots(args.dir, args.samples, args.x, args.y, args.offset)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -132,7 +132,7 @@ def make_plot(type, data, x, qname, outdir, offset):
     plt.savefig(f'{outdir}/{type}_{qname}.pdf',bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir, sample_list, x, y, offset):
+def make_all_plots(outdir, types, sample_list, x, y, offset):
     data = {} # hists + metadata for all models
 
     for sample in samples:
@@ -153,16 +153,18 @@ def make_all_plots(outdir, sample_list, x, y, offset):
     os.makedirs(outdir, exist_ok=True)
     for qname in y:
         processed = process_data(data, x, qname)
-        for plot_type in ['stat','violin']:
+        for plot_type in types:
             make_plot(plot_type, processed, x, qname, outdir, offset)
 
 if __name__=="__main__":
+    allowed_types = ['stat', 'violin']
     qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']
 
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
     )
     parser.add_argument("--dir", type=str, default="All_metaplots", help="output directory")
+    parser.add_argument("--types", type=str, default=allowed_types, nargs='*', choices=allowed_types, help="plot types")
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
     parser.add_argument("-x", type=str, default='rinv', help="x variable")
     parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")
@@ -173,4 +175,4 @@ if __name__=="__main__":
     if unknown_samples:
         raise ValueError("Unknown sample(s) requested:",','.join(unknown_samples))
 
-    make_all_plots(args.dir, args.samples, args.x, args.y, args.offset)
+    make_all_plots(args.dir, args.types, args.samples, args.x, args.y, args.offset)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -79,7 +79,7 @@ def make_plot(type, data, x, qname, outdir, offset):
 
             # compute quantities for plotting
             binned_maxs = np.max(hists, axis=1)
-            x_locs = np.arange(0, sum(binned_maxs), np.max(binned_maxs))
+            x_locs = np.cumsum(binned_maxs) - 0.5 * binned_maxs
             heights = np.diff(bin_edges)
             centers = bin_edges[:-1] + heights/2
 

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -177,7 +177,16 @@ def make_all_plots(outdir, types, sample_list, x, y, xlabel, forcex, offset):
 
 if __name__=="__main__":
     allowed_types = ['stat', 'violin']
-    qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv_proj','DiDHIVJet_rinv_proj','DHIVJet12_rinv_proj_global']
+    qtys_default = [
+        'stable_invisible_fraction',
+        'alpha_3body',
+        'DHIVJet12_rinv_proj',
+        'DiDHIVJet_rinv_proj',
+        'DHIVJet12_rinv_proj_global',
+        'DHIVJet12_rinv_shape',
+        'DiDHIVJet_rinv_shape',
+        'DHIVJet12_rinv_shape_global',
+    ]
 
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -68,39 +68,56 @@ def make_plot(type, data, x, qname, outdir, offset):
     # advance iterator if requested
     next(itertools.islice(props, offset, offset), None)
     ylim = None
-    for entry in data:
-        style = next(props)
-        if type=='stat':
+    if type=='stat':
+        for entry in data:
+            style = next(props)
             # means
             line, = ax.plot(entry['xvals'], entry['means'], label=entry['sample'], fillstyle='none', **style)
             # stderr as errorbar
             ax.errorbar(entry['xvals'], entry['means'], yerr=entry['stderrs'], fmt='none', ecolor=style['color'], capsize=3, **style)
             # stdev as filled
             ax.fill_between(entry['xvals'], entry['means']-entry['stdevs'], entry['means']+entry['stdevs'], color=style['color'], alpha=0.15)
-        elif type=='violin':
+    elif type=='violin':
+        # get global max hist height for each xval
+        all_hists = []
+        samples = []
+        labels = []
+        bin_edges = []
+        heights = []
+        centers = []
+        max_per_label = []
+        for entry in data:
             if len(entry['hists'])==0:
                 continue
 
+            # these are assumed to be shared across all samples
+            if len(labels)==0:
+                labels = entry['xvals']
+                bin_edges = entry['hists'][0].axes[0].edges
+                ylim = (bin_edges[0], bin_edges[-1])
+                heights = np.diff(bin_edges)
+                centers = bin_edges[:-1] + heights/2
             # extract values from histograms
-            hists = [h.values() for h in entry['hists']]
-            labels = entry['xvals']
-            bin_edges = entry['hists'][0].axes[0].edges
-            ylim = (bin_edges[0], bin_edges[-1])
+            all_hists.append({x:h.values() for x,h in zip(entry['xvals'],entry['hists'])})
+            samples.append(entry['sample'])
 
-            # compute quantities for plotting
-            binned_maxs = np.max(hists, axis=1)
-            x_locs = np.cumsum(binned_maxs) - 0.5 * binned_maxs
-            heights = np.diff(bin_edges)
-            centers = bin_edges[:-1] + heights/2
+        # get global max hist height for each xval
+        for label in labels:
+            max_per_label.append(max([max(h[label]) for h in all_hists]))
+        widths = np.array(max_per_label)
+        x_locs = np.cumsum(widths) - 0.5 * widths
 
+        for hists,sample in zip(all_hists, samples):
+            style = next(props)
             # plot all hists from this sample
             style.update({
                 'fc': 'none',
                 'ec': style['color'],
-                'label': entry['sample']
+                'label': sample,
             })
             style.pop('marker')
-            for x_loc, hist in zip(x_locs, hists):
+            for x_loc, label in zip(x_locs, labels):
+                hist = hists[label]
                 lefts = x_loc - 0.5 * hist
                 ax.barh(centers, hist, height=heights, left=lefts, **style)
                 # only apply label once

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -35,37 +35,70 @@ lines = ["solid", "dashed", "dotted", "dashdot", (0, (3, 5, 1, 5, 1, 5)), (0, (3
 markers = ['o', 's', 'D', 'v', '^', '*']
 custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines) + mpl.cycler(marker=markers)
 
+def process_data(data, x, qname):
+    processed = []
+    for sample, models in data.items():
+        xvals = np.array([model['meta'][x] for model in models])
+        means, stdevs, stderrs, hists = zip(*[
+            (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr'], model['hist'][qname]) for model in models
+        ])
+        # order by rinv_pred
+        order = np.argsort(xvals)
+        processed_dict = dict(
+            sample = sample,
+            xvals = xvals[order],
+            means = np.array(means)[order],
+            stdevs = np.array(stdevs)[order],
+            stderrs = np.array(stderrs)[order],
+            hists = [hists[i] for i in order],
+        )
+        processed.append(processed_dict)
+    return processed
+
 # helper to make a plot
-def stat_plot(data, x, qname, outdir, offset):
+def make_plot(type, data, x, qname, outdir, offset):
     fig, ax = plt.subplots(figsize=(8,6))
     # iterator for manual control
     props = iter(custom_cycler)
     # advance iterator if requested
     next(itertools.islice(props, offset, offset), None)
-    for sample, models in data.items():
+    for entry in data:
         style = next(props)
-        xvals = np.array([model['meta'][x] for model in models])
-        means, stdevs, stderrs = zip(*[
-            (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr']) for model in models
-        ])
-        # order by rinv_pred
-        order = np.argsort(xvals)
-        xvals = xvals[order]
-        means = np.array(means)[order]
-        stdevs = np.array(stdevs)[order]
-        stderrs = np.array(stderrs)[order]
-        # means
-        line, = ax.plot(xvals, means, label=sample, fillstyle='none', **style)
-        color = line.get_color()
-        # stderr as errorbar
-        ax.errorbar(xvals, means, yerr=stderrs, fmt='none', ecolor=style['color'], capsize=3, **style)
-        # stdev as filled
-        ax.fill_between(xvals, means-stdevs, means+stdevs, color=style['color'], alpha=0.15)
-    ax.axline((0,0), slope=1, color='black', linestyle=':')
+        if type=='stat':
+            # means
+            line, = ax.plot(entry['xvals'], entry['means'], label=entry['sample'], fillstyle='none', **style)
+            # stderr as errorbar
+            ax.errorbar(entry['xvals'], entry['means'], yerr=entry['stderrs'], fmt='none', ecolor=style['color'], capsize=3, **style)
+            # stdev as filled
+            ax.fill_between(entry['xvals'], entry['means']-entry['stdevs'], entry['means']+entry['stdevs'], color=style['color'], alpha=0.15)
+        elif type=='violin':
+            # extract values from histograms
+            hists = [h.values() for h in entry['hists']]
+            bin_edges = entry['hists'][0].axes[0].edges
+            labels = entry['xvals']
+
+            # compute quantities for plotting
+            binned_maxs = np.max(hists, axis=1)
+            x_locs = np.arange(0, sum(binned_maxs), np.max(binned_maxs))
+            heights = np.diff(bin_edges)
+            centers = bin_edges[:-1] + heights/2
+
+            # plot all hists from this sample
+            style.update({
+                'fc': 'none',
+                'ec': style['color'],
+            })
+            style.pop('marker')
+            for x_loc, hist in zip(x_locs, hists):
+                lefts = x_loc - 0.5 * hist
+                ax.barh(centers, hist, height=heights, left=lefts, **style)
+            ax.set_xticks(x_locs, labels)
+    if type=='stat':
+        ax.axline((0,0), slope=1, color='black', linestyle=':')
     ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')
     ax.set_ylabel(qname)
     ax.legend(framealpha=0.5)
-    plt.savefig('{}/stat_{}.pdf'.format(outdir,qname),bbox_inches='tight')
+    plt.savefig(f'{outdir}/{type}_{qname}.pdf',bbox_inches='tight')
     plt.close(fig)
 
 def make_all_plots(outdir, sample_list, x, y, offset):
@@ -86,7 +119,9 @@ def make_all_plots(outdir, sample_list, x, y, offset):
 
     os.makedirs(outdir, exist_ok=True)
     for qname in y:
-        stat_plot(data, x, qname, outdir, offset)
+        processed = process_data(data, x, qname)
+        for plot_type in ['stat','violin']:
+            make_plot(plot_type, processed, x, qname, outdir, offset)
 
 if __name__=="__main__":
     qtys_default = ['stable_invisible_fraction','DHIVJet12_rinv','DiDHIVJet_rinv','DHIVJet12_rinv_global']

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -16,6 +16,12 @@ samples = [
     {"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
     {"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
 ]
+# account for two complete models with rinv=0.75
+for sample in samples:
+    if "simp" in sample["name"]:
+        idx = next((i for i, val in enumerate(sample["models"]) if 'rinv-0.75' in val), None)
+        if idx is not None:
+            sample["models"].insert(idx+1, sample["models"][idx])
 
 # stylistic options
 mpl.rcParams.update({
@@ -35,7 +41,7 @@ lines = ["solid", "dashed", "dotted", "dashdot", (0, (3, 5, 1, 5, 1, 5)), (0, (3
 markers = ['o', 's', 'D', 'v', '^', '*']
 custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines) + mpl.cycler(marker=markers)
 
-def process_data(data, x, qname):
+def process_data(data, x, qname, forcex):
     processed = []
     for sample, models in data.items():
         xvals = np.array([model['meta'][x] for model in models])
@@ -58,6 +64,12 @@ def process_data(data, x, qname):
         elif any(hists_missing):
             raise RuntimeError(f"Missing histogram {qname} in:\n"+','.join([model[file] for i,model in enumerate(models) if hists_missing[i]]))
         processed.append(processed_dict)
+    if forcex:
+        if forcex not in data:
+            raise ValueError(f"Unknown forcex sample {forcex}")
+        forcexvals = next((pd['xvals'] for pd in processed if pd['sample']==forcex))
+        for processed_dict in processed:
+            processed_dict['xvals'] = forcexvals
     return processed
 
 # helper to make a plot
@@ -132,7 +144,7 @@ def make_plot(type, data, x, qname, outdir, offset):
     plt.savefig(f'{outdir}/{type}_{qname}.pdf',bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir, types, sample_list, x, y, offset):
+def make_all_plots(outdir, types, sample_list, x, y, forcex, offset):
     data = {} # hists + metadata for all models
 
     for sample in samples:
@@ -152,7 +164,7 @@ def make_all_plots(outdir, types, sample_list, x, y, offset):
 
     os.makedirs(outdir, exist_ok=True)
     for qname in y:
-        processed = process_data(data, x, qname)
+        processed = process_data(data, x, qname, forcex)
         for plot_type in types:
             make_plot(plot_type, processed, x, qname, outdir, offset)
 
@@ -167,6 +179,7 @@ if __name__=="__main__":
     parser.add_argument("--types", type=str, default=allowed_types, nargs='*', choices=allowed_types, help="plot types")
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
     parser.add_argument("-x", type=str, default='rinv', help="x variable")
+    parser.add_argument("--forcex", type=str, default=None, help="force use of x values from specified sample")
     parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")
     parser.add_argument("--offset", type=int, default=0, help="offset for color/style cycler")
     args = parser.parse_args()
@@ -175,4 +188,4 @@ if __name__=="__main__":
     if unknown_samples:
         raise ValueError("Unknown sample(s) requested:",','.join(unknown_samples))
 
-    make_all_plots(args.dir, args.types, args.samples, args.x, args.y, args.offset)
+    make_all_plots(args.dir, args.types, args.samples, args.x, args.y, args.forcex, args.offset)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -10,10 +10,10 @@ from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 from glob import glob
 
 samples = [
-	{"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
-	{"name": "simp", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
-	{"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
-	{"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+    {"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+    {"name": "simp", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+    {"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+    {"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
 ]
 
 # stylistic options
@@ -31,30 +31,19 @@ colors = ["#e42536", "#5790fc", "#964a8b", "#f89c20", "#7a21dd", "#9c9ca1"]
 
 # last two are dashdotdot and dashdashdot
 lines = ["solid", "dashed", "dotted", "dashdot", (0, (3, 5, 1, 5, 1, 5)), (0, (3, 5, 3, 5, 1, 5))]
-custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines)
-
-data = {} # hists + metadata for all models
-
-for sample in samples:
-    data[sample["name"]] = []
-    for model in sample['models']:
-        file = f'{model}/Hists.pkl'
-
-        with open(file, "rb") as inp:
-            data_model = pickle.load(inp)
-
-        data[sample["name"]].append(data_model)
+markers = ['o', 's', 'D', 'v', '^', '*']
+custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines) + mpl.cycler(marker=markers)
 
 # helper to make a plot
-def stat_plot(qname, outdir):
+def stat_plot(data, x, qname, outdir):
     fig, ax = plt.subplots(figsize=(8,6))
     # iterator for manual control
     props = iter(custom_cycler)
     for sample, models in data.items():
         style = next(props)
-        xvals = np.array([model['model']['rinv'] for model in models])
+        xvals = np.array([model['meta'][x] for model in models])
         means, stdevs, stderrs = zip(*[
-            (model['analysis'][qname]['mean'], model['analysis'][qname]['stdev'], model['analysis'][qname]['stderr']) for model in models
+            (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr']) for model in models
         ])
         # order by rinv_pred
         order = np.argsort(xvals)
@@ -63,28 +52,51 @@ def stat_plot(qname, outdir):
         stdevs = np.array(stdevs)[order]
         stderrs = np.array(stderrs)[order]
         # means
-        line, = ax.plot(xvals, means, 'o-', label=sample, **style)
+        line, = ax.plot(xvals, means, label=sample, fillstyle='none', **style)
         color = line.get_color()
         # stderr as errorbar
         ax.errorbar(xvals, means, yerr=stderrs, fmt='none', ecolor=style['color'], capsize=3, **style)
         # stdev as filled
         ax.fill_between(xvals, means-stdevs, means+stdevs, color=style['color'], alpha=0.15)
+    ax.axline((0,0), slope=1, color='black', linestyle=':')
     ax.set_xlabel(r'$r_{\text{inv}}^{\text{pred}}$')
     ax.set_ylabel(qname)
     ax.legend(framealpha=0.5)
     plt.savefig('{}/stat_{}.pdf'.format(outdir,qname),bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir):
+def make_all_plots(outdir, sample_list, x, y):
+    data = {} # hists + metadata for all models
+
+    for sample in samples:
+        if sample_list and sample["name"] not in sample_list: continue
+        data[sample["name"]] = []
+        for model in sample['models']:
+            file = f'{model}/Hists.pkl'
+
+            with open(file, "rb") as inp:
+                data_model = pickle.load(inp)
+                # join these for ease of use
+                data_model['meta'] = data_model['model'] | data_model['analysis']
+
+            data[sample["name"]].append(data_model)
+
     os.makedirs(outdir, exist_ok=True)
-    for qname in ['stability','DHJet12_rinv']:
-        stat_plot(qname, outdir)
+    for qname in y:
+        stat_plot(data, x, qname, outdir)
 
 if __name__=="__main__":
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
     )
     parser.add_argument("--dir", type=str, default="All_metaplots", help="output directory")
+    parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
+    parser.add_argument("-x", type=str, default='rinv', help="x variable")
+    parser.add_argument("-y", type=str, default=['stability','DHJet12_rinv'], nargs='*', help="y variable(s)")
     args = parser.parse_args()
 
-    make_all_plots(args.dir)
+    unknown_samples = [s for s in args.samples if not any([s==sm['name'] for sm in samples])]
+    if unknown_samples:
+        raise ValueError("Unknown sample(s) requested:",','.join(unknown_samples))
+
+    make_all_plots(args.dir, args.samples, args.x, args.y)

--- a/Plots.py
+++ b/Plots.py
@@ -57,7 +57,7 @@ for sample in samples:
     with open(file, "rb") as inp:
         hists_model=pickle.load(inp)                # Dict Contains all the histos for 1 model
 
-    hists[sample["name"]] = hists_model
+    hists[sample["name"]] = hists_model['hist']
 
 # helper to make a plot
 def make_plot(hname):                         # hists is a dict containing

--- a/Plots.py
+++ b/Plots.py
@@ -62,29 +62,30 @@ for sample in samples:
     hists[sample["name"]] = hists_model['hist']
 
 # helper to make a plot
-def make_plot(hname,outdir):
+def make_plot(hname,outdir,liny=False):
     fig, ax = plt.subplots(figsize=(8,6))
     ax.set_prop_cycle(custom_cycler)
     for i,(l,h) in enumerate(hists.items()):                       # h is a list of hist objects
         if not hname in h: return
         hep.histplot(h[hname],density=True,ax=ax,label=l,flow="none",yerr=0)
     ax.set_xlim(h[hname].axes[0].edges[0],h[hname].axes[0].edges[-1])
-    ax.set_yscale("log")
+    if not liny: ax.set_yscale("log")
     ax.set_ylabel("Arbitrary units")
     ax.legend(framealpha=0.5)
     plt.savefig('{}/{}.pdf'.format(outdir,hname),bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots(outdir):
+def make_all_plots(outdir, liny):
     os.makedirs(outdir,exist_ok=True)
     for hname in hists[samples[0]["name"]]:
-        make_plot(hname,outdir)
+        make_plot(hname,outdir,liny=any([x in hname for x in liny]))
 
 if __name__=="__main__":
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsRawHelpFormatter
     )
     parser.add_argument("--dir", type=str, default="All_plots", help="output directory")
+    parser.add_argument("--liny", type=str, default=[], nargs='*', help="plot histograms with matching names in linear scale")
     args = parser.parse_args()
 
-    make_all_plots(args.dir)
+    make_all_plots(args.dir, args.liny)

--- a/Plots.py
+++ b/Plots.py
@@ -8,15 +8,20 @@ import pickle
 from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 
 samples = [
+    {"name": r"FCDC", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
+    {"name": r"simp", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
+    {"name": r"FCDC (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
+    {"name": r"simp (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
+
     #{"name": r"CMS", "model": "s-channel_mmed-1000_Nc-2_Nf-2_scale-35.1539_mq-10_mpi-20_mrho-20_pvector-0.75_spectrum-cms_rinv-0.3/"}
     # {"name": r"CMS ($r_{\text{inv}} = 0.667$)", "model": "s-channel_mmed-1000_Nc-2_Nf-2_scale-35.1539_mq-10_mpi-20_mrho-20_pvector-0.75_spectrum-cms_rinv-0.666667"},
     # {"name": r"Snowmass ($m_{\text{dark}} = 20\,\text{GeV}$)", "model": "s-channel_mmed-1000_Nc-3_Nf-3_scale-33.3333_mq-33.73_mpi-20_mrho-83.666_pvector-0.5_spectrum-snowmass_rinv-0"},
-    {"name": r"fcdc_rinv0p5", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.5"},
+    # {"name": r"fcdc_rinv0p5", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.5"},
     # {"name": r"fcdc_rinv0p4", "model": "fcdc/s-channel_mmed-1000_Nc-4_Nf-4_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.4"},
     # {"name": r"fcdc_rinv0p67", "model": "fcdc/s-channel_mmed-1000_Nc-4_Nf-4_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.666667"},
     # {"name": r"fcdc_rinv0p33", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.333333"},
     # {"name": r"fcdc_rinv0p58", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.583333"},
-    {"name": r"fcdc_rinv0p75", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.75"},
+    # {"name": r"fcdc_rinv0p75", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.75"},
     # {"name": r"fcdc_rinv0p28", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.285714"},
     # {"name": r"fcdc_rinv0p51", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.514286"},
     # {"name": r"fcdc_rinv0p69", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.685714"},
@@ -26,12 +31,12 @@ samples = [
     # {"name": r"fcdc_rinv0p625", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.625"},
     # {"name": r"fcdc_rinv0p75", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.75"},
     # {"name": r"fcdc_rinv0p83", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.833333"},
-    {"name": r"fcdc_rinv0p22", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.222222"},
+    # {"name": r"fcdc_rinv0p22", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.222222"},
     # {"name": r"fcdc_rinv0p41", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.412698"},
     # {"name": r"fcdc_rinv0p57", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.571429"},
     # {"name": r"fcdc_rinv0p7", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.698413"},
     # {"name": r"fcdc_rinv0p79", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.793651"},
-    {"name": r"fcdc_rinv0p85", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.857143"},
+    # {"name": r"fcdc_rinv0p85", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.857143"},
 ]
 
 # stylistic options

--- a/Plots.py
+++ b/Plots.py
@@ -5,6 +5,7 @@ mpl.use('Agg')
 import matplotlib.pyplot as plt
 import mplhep as hep
 import pickle
+from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 
 samples = [
     #{"name": r"CMS", "model": "s-channel_mmed-1000_Nc-2_Nf-2_scale-35.1539_mq-10_mpi-20_mrho-20_pvector-0.75_spectrum-cms_rinv-0.3/"}
@@ -61,7 +62,7 @@ for sample in samples:
     hists[sample["name"]] = hists_model['hist']
 
 # helper to make a plot
-def make_plot(hname):                         # hists is a dict containing
+def make_plot(hname,outdir):
     fig, ax = plt.subplots(figsize=(8,6))
     ax.set_prop_cycle(custom_cycler)
     for i,(l,h) in enumerate(hists.items()):                       # h is a list of hist objects
@@ -71,14 +72,19 @@ def make_plot(hname):                         # hists is a dict containing
     ax.set_yscale("log")
     ax.set_ylabel("Arbitrary units")
     ax.legend(framealpha=0.5)
-    outdir = "All_plots"
-    os.makedirs(outdir,exist_ok=True)
     plt.savefig('{}/{}.pdf'.format(outdir,hname),bbox_inches='tight')
     plt.close(fig)
 
-def make_all_plots():
+def make_all_plots(outdir):
+    os.makedirs(outdir,exist_ok=True)
     for hname in hists[samples[0]["name"]]:
-        make_plot(hname)
+        make_plot(hname,outdir)
 
 if __name__=="__main__":
-    make_all_plots()
+    parser = ArgumentParser(
+        formatter_class=ArgumentDefaultsRawHelpFormatter
+    )
+    parser.add_argument("--dir", type=str, default="All_plots", help="output directory")
+    args = parser.parse_args()
+
+    make_all_plots(args.dir)

--- a/Plots.py
+++ b/Plots.py
@@ -45,9 +45,10 @@ mpl.rcParams.update({
 # based on https://github.com/mpetroff/accessible-color-cycles
 # red, blue, mauve, orange, purple, gray,
 colors = ["#e42536", "#5790fc", "#964a8b", "#f89c20", "#7a21dd", "#9c9ca1"]
-mpl.rcParams['axes.prop_cycle'] = mpl.cycler(color=colors)
 
-
+# last two are dashdotdot and dashdashdot
+lines = ["solid", "dashed", "dotted", "dashdot", (0, (3, 5, 1, 5, 1, 5)), (0, (3, 5, 3, 5, 1, 5))]
+custom_cycler = mpl.cycler(color=colors) + mpl.cycler(linestyle=lines)
 
 hists = {}      # Contains the lists of histos for all models
 
@@ -62,7 +63,9 @@ for sample in samples:
 # helper to make a plot
 def make_plot(hname):                         # hists is a dict containing
     fig, ax = plt.subplots(figsize=(8,6))
-    for l,h in hists.items():                       # h is a list of hist objects
+    ax.set_prop_cycle(custom_cycler)
+    for i,(l,h) in enumerate(hists.items()):                       # h is a list of hist objects
+        if not hname in h: return
         hep.histplot(h[hname],density=True,ax=ax,label=l,flow="none",yerr=0)
     ax.set_xlim(h[hname].axes[0].edges[0],h[hname].axes[0].edges[-1])
     ax.set_yscale("log")

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source init.sh
 This repository is built on the [LCG 106](https://lcginfo.cern.ch/release_packages/106/x86_64-el9-gcc13-opt/) environment.
 Important software versions:
 * Pythia8 3.10
-* Delphes 3.5.1pre09
+* Delphes 3.5.1 (patched)
 * HepMC 2.06.11
 * ROOT 6.32.02
 * coffea 2025.12.0

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -42,6 +42,7 @@ set ExecutionPath {
   GenMissingET
   DarkHadronFilter
   DarkHadronJetFinder
+  DarkHadronVisibleJetFinder
   
   FastJetFinder
   FatJetFinder
@@ -660,6 +661,7 @@ module PdgCodeFilter DarkHadronFilter {
   set OutputArray filteredParticles
 
   set PTMin 0.0
+  set FirstDark 1
   set Invert 1
 
 $HVDarkHadronFilter
@@ -688,6 +690,34 @@ module FastJetFinder DarkHadronJetFinder {
   set R0SoftDrop 0.8
 
   set JetPTMin 15.0
+}
+
+#######################################################################
+# Visible jet manually assembled from decay products of dark hadron jet
+#######################################################################
+
+module FastJetFinder DarkHadronVisibleJetFinder {
+  set InputArray NeutrinoFilter/filteredParticles
+  set DarkHadronJetArray DarkHadronJetFinder/jets
+  set ParticleInputArray Delphes/allParticles
+
+  set OutputArray jets
+
+  # kDarkHadronVisibleMatch
+  set JetAlgorithm 20
+  # for substructure tools
+  set ParameterR 0.8
+  set JetPTMin 0.0
+
+  # All standard FastJetFinder substructure options work unchanged:
+  set ComputeNsubjettiness 1
+  set Beta 1.0
+  set AxisMode 4
+
+  set ComputeSoftDrop 1
+  set BetaSoftDrop 0.0
+  set SymmetryCutSoftDrop 0.1
+  set R0SoftDrop 0.8
 }
 
 ############
@@ -851,6 +881,7 @@ module TreeWriter TreeWriter {
   # dark hadron jet collections
   add Branch DarkHadronFilter/filteredParticles DarkHadronCandidate GenParticle
   add Branch DarkHadronJetFinder/jets DarkHadronJet Jet
+  add Branch DarkHadronVisibleJetFinder/jets DarkHadronVisibleJet Jet
 
   add Branch UniqueObjectFinder/jets Jet Jet
   add Branch UniqueObjectFinder/electrons Electron Electron

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -43,6 +43,9 @@ set ExecutionPath {
   DarkHadronFilter
   DarkHadronJetFinder
   DarkHadronVisibleJetFinder
+  DarkHadronFinalFilter
+  StableParticleMerger
+  DarkHadronStableJetFinder
   
   FastJetFinder
   FatJetFinder
@@ -720,6 +723,63 @@ module FastJetFinder DarkHadronVisibleJetFinder {
   set R0SoftDrop 0.8
 }
 
+###########################
+# Stable dark hadron finder
+###########################
+
+module PdgCodeFilter DarkHadronFinalFilter {
+
+  set InputArray Delphes/allParticles
+  set OutputArray filteredParticles
+
+  set PTMin 0.0
+  set Invert 1
+
+$HVDarkHadronFinalFilter
+
+  set StableDark 1
+
+$HVDaughterFilter
+}
+
+######################
+# All stable particles
+######################
+
+module Merger StableParticleMerger {
+  add InputArray NeutrinoFilter/filteredParticles
+  add InputArray DarkHadronFinalFilter/filteredParticles
+  set OutputArray particles
+}
+
+####################
+# Visible+stable jet
+####################
+
+module FastJetFinder DarkHadronStableJetFinder {
+  set InputArray StableParticleMerger/particles
+  set DarkHadronJetArray DarkHadronJetFinder/jets
+  set ParticleInputArray Delphes/allParticles
+
+  set OutputArray jets
+
+  # kDarkHadronVisibleMatch
+  set JetAlgorithm 20
+  # for substructure tools
+  set ParameterR 0.8
+  set JetPTMin 0.0
+
+  # All standard FastJetFinder substructure options work unchanged:
+  set ComputeNsubjettiness 1
+  set Beta 1.0
+  set AxisMode 4
+
+  set ComputeSoftDrop 1
+  set BetaSoftDrop 0.0
+  set SymmetryCutSoftDrop 0.1
+  set R0SoftDrop 0.8
+}
+
 ############
 # Jet finder
 ############
@@ -864,6 +924,7 @@ module TreeWriter TreeWriter {
 # add Branch InputArray BranchName BranchClass
   add Branch Delphes/allParticles GenParticle GenParticle
   add Branch NeutrinoFilter/filteredParticles GenCandidate GenParticle
+  add Branch StableParticleMerger/particles GenStableCandidate GenParticle
 
   add Branch TrackMerger/tracks Track Track
   add Branch Calorimeter/towers Tower Tower
@@ -882,6 +943,7 @@ module TreeWriter TreeWriter {
   add Branch DarkHadronFilter/filteredParticles DarkHadronCandidate GenParticle
   add Branch DarkHadronJetFinder/jets DarkHadronJet Jet
   add Branch DarkHadronVisibleJetFinder/jets DarkHadronVisibleJet Jet
+  add Branch DarkHadronStableJetFinder/jets DarkHadronStableJet Jet
 
   add Branch UniqueObjectFinder/jets Jet Jet
   add Branch UniqueObjectFinder/electrons Electron Electron

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -37,6 +37,7 @@ set ExecutionPath {
   MissingET
 
   NeutrinoFilter
+  NeutrinoKeeper
   GenJetFinder
   GenFatJetFinder
   GenMissingET
@@ -608,6 +609,26 @@ $HVNuFilter
 }
 
 #####################
+# Neutrino Keeper
+#####################
+
+module PdgCodeFilter NeutrinoKeeper {
+
+  set InputArray Delphes/stableParticles
+  set OutputArray filteredParticles
+
+  set PTMin 0.0
+  set Invert 1
+
+  add PdgCode {12}
+  add PdgCode {14}
+  add PdgCode {16}
+  add PdgCode {-12}
+  add PdgCode {-14}
+  add PdgCode {-16}
+}
+
+#####################
 # MC truth jet finder
 #####################
 
@@ -748,6 +769,7 @@ $HVDaughterFilter
 
 module Merger StableParticleMerger {
   add InputArray NeutrinoFilter/filteredParticles
+  add InputArray NeutrinoKeeper/filteredParticles
   add InputArray DarkHadronFinalFilter/filteredParticles
   set OutputArray particles
 }

--- a/common.py
+++ b/common.py
@@ -8,6 +8,9 @@ from coffea.nanoevents.methods.delphes import behavior, _set_repr_name, Particle
 
 DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",
+    "DarkHadronCandidate": "Particle",
+    "GenCandidate": "Particle",
+    "GenParticle": "Particle",
     "FatJet": "Jet",
     "GenFatJet": "Jet",
     "DarkHadronJet": "Jet",
@@ -15,21 +18,15 @@ DelphesSchema.mixins.update({
 
 # workaround for https://cp3.irmp.ucl.ac.be/projects/delphes/ticket/1170
 # manually fix mass units
-
-@ak.mixin_class(behavior)
-class GenParticle(Particle):
-    @property
-    def mass(self):
-        return self["Mass"]*0.001
-
-_set_repr_name("GenParticle")
-
-# propagate usage to schema, only for generator particles
-DelphesSchema.mixins.update({
-    "GenParticle": "GenParticle",
-    "GenCandidate": "GenParticle",
-    "DarkHadronCandidate": "GenParticle",
-})
+def fix_delphes_mass_units(events):
+    GenParticleCollections = [
+        "GenParticle",
+        "GenCandidate",
+        "DarkHadronCandidate",
+    ]
+    for col in GenParticleCollections:
+        events[col, "Mass"] = events[col]["Mass"]*0.001
+    return events
 
 class DelphesSchema2(DelphesSchema):
     jet_const_pairs = {
@@ -174,7 +171,10 @@ def load_events(filename,schema=DelphesSchema,metadict=None,with_constituents=Fa
         metadata=metadict,
     ).events()
 
+    events = fix_delphes_mass_units(events)
+
     if with_constituents:
         events = init_constituents(events)
+
     return events
 

--- a/common.py
+++ b/common.py
@@ -10,11 +10,13 @@ DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",
     "DarkHadronCandidate": "Particle",
     "GenCandidate": "Particle",
+    "GenStableCandidate": "Particle",
     "GenParticle": "Particle",
     "FatJet": "Jet",
     "GenFatJet": "Jet",
     "DarkHadronJet": "Jet",
     "DarkHadronVisibleJet": "Jet",
+    "DarkHadronStableJet": "Jet",
 })
 
 # workaround for https://cp3.irmp.ucl.ac.be/projects/delphes/ticket/1170
@@ -23,6 +25,7 @@ def fix_delphes_mass_units(events):
     GenParticleCollections = [
         "GenParticle",
         "GenCandidate",
+        "GenStableCandidate",
         "DarkHadronCandidate",
     ]
     for col in GenParticleCollections:
@@ -35,6 +38,7 @@ class DelphesSchema2(DelphesSchema):
         "Jet" : "ParticleFlowCandidate",
         "DarkHadronJet" : "DarkHadronCandidate",
         "DarkHadronVisibleJet": "GenCandidate",
+        "DarkHadronStableJet": "GenStableCandidate",
         "GenFatJet" : "GenCandidate",
         "GenJet" : "GenCandidate",
     }

--- a/common.py
+++ b/common.py
@@ -14,6 +14,7 @@ DelphesSchema.mixins.update({
     "FatJet": "Jet",
     "GenFatJet": "Jet",
     "DarkHadronJet": "Jet",
+    "DarkHadronVisibleJet": "Jet",
 })
 
 # workaround for https://cp3.irmp.ucl.ac.be/projects/delphes/ticket/1170
@@ -33,6 +34,7 @@ class DelphesSchema2(DelphesSchema):
         "FatJet" : "ParticleFlowCandidate",
         "Jet" : "ParticleFlowCandidate",
         "DarkHadronJet" : "DarkHadronCandidate",
+        "DarkHadronVisibleJet": "GenCandidate",
         "GenFatJet" : "GenCandidate",
         "GenJet" : "GenCandidate",
     }

--- a/configs/model_fcdc_mpi10.py
+++ b/configs/model_fcdc_mpi10.py
@@ -1,0 +1,6 @@
+from model_fcdc_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+# generate new configs for each input
+common = masses_snowmass(config=common,scale=10/0.6,mpi_over_scale=0.6)
+config = fcdc_configs_NcNf1(common=common)

--- a/configs/model_fcdc_mpi10_3body.py
+++ b/configs/model_fcdc_mpi10_3body.py
@@ -1,0 +1,7 @@
+from model_fcdc_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+# from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
+common = masses_snowmass(config=common,scale=10/1.7,mpi_over_scale=1.7)
+# generate new configs for each input
+config = fcdc_configs_NcNf1(common=common)

--- a/configs/model_fcdc_mpi6.py
+++ b/configs/model_fcdc_mpi6.py
@@ -1,0 +1,6 @@
+from model_fcdc_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+# generate new configs for each input
+common = masses_snowmass(config=common,scale=6/0.6,mpi_over_scale=0.6)
+config = fcdc_configs_NcNf1(common=common)

--- a/configs/model_fcdc_mpi6_3body.py
+++ b/configs/model_fcdc_mpi6_3body.py
@@ -1,0 +1,7 @@
+from model_fcdc_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+# from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
+common = masses_snowmass(config=common,scale=6/1.7,mpi_over_scale=1.7)
+# generate new configs for each input
+config = fcdc_configs_NcNf1(common=common)

--- a/configs/model_snowmass_fcdclike.py
+++ b/configs/model_snowmass_fcdclike.py
@@ -1,7 +1,6 @@
-from model_snowmass_base import config
-from svjHelper import masses_snowmass
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
 
-config = masses_snowmass(config=config,scale=10,mpi_over_scale=0.6)
-
-config.rinv = 0.5
-config.spectrum = 'fcdcSimp'
+common = masses_snowmass(config=common,scale=10,mpi_over_scale=0.6)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/configs/model_snowmass_fcdclike_3body.py
+++ b/configs/model_snowmass_fcdclike_3body.py
@@ -1,8 +1,7 @@
-from model_snowmass_base import config
-from svjHelper import masses_snowmass
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
 
 # from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
-config = masses_snowmass(config=config,scale=10,mpi_over_scale=1.7)
-
-config.rinv = 0.5
-config.spectrum = 'fcdcSimp'
+common = masses_snowmass(config=common,scale=10,mpi_over_scale=1.7)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/configs/model_snowmass_fcdclike_mpi10.py
+++ b/configs/model_snowmass_fcdclike_mpi10.py
@@ -1,0 +1,7 @@
+from model_snowmass_base import config
+from svjHelper import masses_snowmass
+
+config = masses_snowmass(config=config,scale=10/0.6,mpi_over_scale=0.6)
+
+config.rinv = 0.5
+config.spectrum = 'fcdcSimp'

--- a/configs/model_snowmass_fcdclike_mpi10.py
+++ b/configs/model_snowmass_fcdclike_mpi10.py
@@ -1,7 +1,6 @@
-from model_snowmass_base import config
-from svjHelper import masses_snowmass
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
 
-config = masses_snowmass(config=config,scale=10/0.6,mpi_over_scale=0.6)
-
-config.rinv = 0.5
-config.spectrum = 'fcdcSimp'
+common = masses_snowmass(config=common,scale=10/0.6,mpi_over_scale=0.6)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/configs/model_snowmass_fcdclike_mpi10_3body.py
+++ b/configs/model_snowmass_fcdclike_mpi10_3body.py
@@ -1,0 +1,8 @@
+from model_snowmass_base import config
+from svjHelper import masses_snowmass
+
+# from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
+config = masses_snowmass(config=config,scale=10/1.7,mpi_over_scale=1.7)
+
+config.rinv = 0.5
+config.spectrum = 'fcdcSimp'

--- a/configs/model_snowmass_fcdclike_mpi10_3body.py
+++ b/configs/model_snowmass_fcdclike_mpi10_3body.py
@@ -1,8 +1,7 @@
-from model_snowmass_base import config
-from svjHelper import masses_snowmass
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
 
 # from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
-config = masses_snowmass(config=config,scale=10/1.7,mpi_over_scale=1.7)
-
-config.rinv = 0.5
-config.spectrum = 'fcdcSimp'
+common = masses_snowmass(config=common,scale=10/1.7,mpi_over_scale=1.7)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/configs/model_snowmass_fcdclike_mpi6.py
+++ b/configs/model_snowmass_fcdclike_mpi6.py
@@ -1,0 +1,6 @@
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+common = masses_snowmass(config=common,scale=6/0.6,mpi_over_scale=0.6)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/configs/model_snowmass_fcdclike_mpi6_3body.py
+++ b/configs/model_snowmass_fcdclike_mpi6_3body.py
@@ -1,0 +1,7 @@
+from model_snowmass_base import config as common
+from svjHelper import masses_snowmass, fcdc_configs_NcNf1
+
+# from mrho_snowmass, mrho > 2mpi -> mpi/scale < sqrt(5.76/2.5) ~ 1.518
+common = masses_snowmass(config=common,scale=6/1.7,mpi_over_scale=1.7)
+common.spectrum = 'fcdcSimp'
+config = fcdc_configs_NcNf1(common=common, simp=True)

--- a/init.sh
+++ b/init.sh
@@ -5,7 +5,7 @@ export LCG_ARCH=x86_64-el9-gcc13-opt
 source /cvmfs/sft.cern.ch/lcg/views/${LCG_VIEW}/${LCG_ARCH}/setup.sh
 
 export MODEL_BUILDING=$PWD
-export MODEL_BUILDING_EXTERNALS="pythia8 python_packages"
+export MODEL_BUILDING_EXTERNALS="pythia8 python_packages delphes"
 
 for EXTERNAL in $MODEL_BUILDING_EXTERNALS; do
 	EXTERNAL_DIR=${MODEL_BUILDING}/install/${EXTERNAL}

--- a/install/delphes.sh
+++ b/install/delphes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+git clone git@github.com:cms-svj/delphes -b DarkHadronJets
+cd delphes
+
+make -j 8
+
+cat << 'EOF' > mb_init.sh
+export DELPHES=${MODEL_BUILDING}/install/delphes
+export PATH=${DELPHES}/:${PATH}
+export LD_LIBRARY_PATH=${DELPHES}/:${LD_LIBRARY_PATH}
+EOF

--- a/run_fcdc_models.py
+++ b/run_fcdc_models.py
@@ -11,7 +11,7 @@ def run_objs(config_name, args, dryrun):
     for obj in objs:
         logName = f'model_{obj}'
         print(obj)
-        cmd = f'./run_model helper -C {config_name} -O {obj} {args} > models/fcdc/{logName}.log'
+        cmd = f'./run_model helper -C {config_name} -O config.{obj} {args} > models/fcdc/{logName}.log'
         print(cmd)
         if not dryrun: os.system(cmd)
 

--- a/run_fcdc_models.py
+++ b/run_fcdc_models.py
@@ -4,12 +4,13 @@ from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 config_dir = os.path.join(os.getcwd(), "configs")
 sys.path.append(config_dir)
 
-def run_objs(config_name, args, dryrun):
+def run_objs(config_name, args, suffix, dryrun):
     configs_fcdc = imp.load_source("configs_fcdc", config_name)
     objs = [obj for obj in vars(configs_fcdc.config)]
 
     for obj in objs:
         logName = f'model_{obj}'
+        if suffix: logName += f'_{suffix}'
         print(obj)
         cmd = f'./run_model helper -C {config_name} -O config.{obj} {args} > models/fcdc/{logName}.log'
         print(cmd)
@@ -21,6 +22,7 @@ if __name__=="__main__":
     )
     parser.add_argument("--config-name", type=str, default="configs/model_fcdc_10.py", help="config file containing multiple models")
     parser.add_argument("--args", type=str, default="--dir models/fcdc --steps all --events 1000 --verbose", help="arguments to pass to run_model")
+    parser.add_argument("--suffix", type=str, default="", help="suffix for log file names")
     parser.add_argument("--dryrun", default=False, action="store_true", help="print commands but don't run")
     args = parser.parse_args()
-    run_objs(args.config_name, args.args, args.dryrun)
+    run_objs(args.config_name, args.args, args.suffix, args.dryrun)

--- a/run_fcdc_models.py
+++ b/run_fcdc_models.py
@@ -5,13 +5,11 @@ sys.path.append(config_dir)
 
 nEvents = 1000
 config_name = "configs/model_fcdc_10.py"
-path = os.path.join(config_dir, "fcdc")
 configs_fcdc = imp.load_source("configs_fcdc", config_name)
-prefix = "config"
-objs = [obj for obj in dir(configs_fcdc) if obj.startswith(prefix) and len(obj)>len(prefix)]
+objs = [obj for obj in vars(configs_fcdc.config)]
 
 for obj in objs:
-    logName = obj.replace(prefix,"model_")
+    logName = f'model_{obj}'
     print(obj)
     cmd = f'./run_model helper -C {config_name} -O {obj} --dir models/fcdc --steps all --events {nEvents} --verbose > models/fcdc/{logName}.log'
     print(cmd)

--- a/run_fcdc_models.py
+++ b/run_fcdc_models.py
@@ -1,16 +1,26 @@
 import os, sys, imp
+from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 
 config_dir = os.path.join(os.getcwd(), "configs")
 sys.path.append(config_dir)
 
-nEvents = 1000
-config_name = "configs/model_fcdc_10.py"
-configs_fcdc = imp.load_source("configs_fcdc", config_name)
-objs = [obj for obj in vars(configs_fcdc.config)]
+def run_objs(config_name, args, dryrun):
+    configs_fcdc = imp.load_source("configs_fcdc", config_name)
+    objs = [obj for obj in vars(configs_fcdc.config)]
 
-for obj in objs:
-    logName = f'model_{obj}'
-    print(obj)
-    cmd = f'./run_model helper -C {config_name} -O {obj} --dir models/fcdc --steps all --events {nEvents} --verbose > models/fcdc/{logName}.log'
-    print(cmd)
-    os.system(cmd)
+    for obj in objs:
+        logName = f'model_{obj}'
+        print(obj)
+        cmd = f'./run_model helper -C {config_name} -O {obj} {args} > models/fcdc/{logName}.log'
+        print(cmd)
+        if not dryrun: os.system(cmd)
+
+if __name__=="__main__":
+    parser = ArgumentParser(
+        formatter_class=ArgumentDefaultsRawHelpFormatter
+    )
+    parser.add_argument("--config-name", type=str, default="configs/model_fcdc_10.py", help="config file containing multiple models")
+    parser.add_argument("--args", type=str, default="--dir models/fcdc --steps all --events 1000 --verbose", help="arguments to pass to run_model")
+    parser.add_argument("--dryrun", default=False, action="store_true", help="print commands but don't run")
+    args = parser.parse_args()
+    run_objs(args.config_name, args.args, args.dryrun)

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -123,7 +123,7 @@ def alpha_mean(*, mrho, mpi):
     alpha = np.mean(alphas)
     return alpha
 
-def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector):
+def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector, alpha=None):
     # off-diagonal pi w/ no FCDC: stable
     # off-diagonal rho w/ no FCDC: decay to pi q qbar (pi stable)
     # all others decay to q qbar (mass insertion or democratic)
@@ -133,20 +133,26 @@ def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector):
     Npi = Nf**2-1 # neglect eta prime
     Nrho = Nf**2
 
+    if alpha is None:
+        alpha = alpha_mean(mrho=mrho, mpi=mpi)
+
     numer_pi = (1-pvector)*Nstable
-    numer_rho = alpha_mean(mrho=mrho, mpi=mpi)*pvector*Nstable
+    numer_rho = alpha*pvector*Nstable
     denom_pi = (1-pvector)*Npi
     denom_rho = pvector*Nrho
 
     rinv = (numer_pi + numer_rho) / (denom_pi + denom_rho)
     return rinv
 
-def fcdc_rinv_3body_simp(*, rinv, Nf, mrho, mpi, pvector):
+def fcdc_rinv_3body_simp(*, rinv, Nf, mrho, mpi, pvector, alpha=None):
     Npi = Nf**2-1 # neglect eta prime
     Nrho = Nf**2
 
+    if alpha is None:
+        alpha = alpha_mean(mrho=mrho, mpi=mpi)
+
     numer_pi = (1-pvector)*rinv*Npi
-    numer_rho = alpha_mean(mrho=mrho, mpi=mpi)*pvector*rinv*Nrho
+    numer_rho = alpha*pvector*rinv*Nrho
     denom_pi = (1-pvector)*Npi
     denom_rho = pvector*Nrho
 

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -35,6 +35,13 @@ def masses_snowmass(*, config, scale, mpi_over_scale):
 def gchi_lhcdm(*, gDM, Nc, Nf):
     return gDM/math.sqrt(Nc*Nf)
 
+# rinv calculation for FCDC complete model
+# neglects eta prime meson: assumed to be heavy (from anomaly), therefore rarely produced
+def fcdc_rinv(*, Nf, Ns):
+    Nu = Nf-Ns
+    rinv = (Nf*(Nf-1) - Nu*(Nu-1)) / (Nf**2 - 1)
+    return rinv
+
 # create a single fcdc config using input numbers
 def fcdc_config(*, common, Nc, Nf, Ns):
     configName = 'Nc{:d}Nf{:d}Ns{:d}'.format(Nc, Nf, Ns)
@@ -42,8 +49,15 @@ def fcdc_config(*, common, Nc, Nf, Ns):
     config.join(common)
     return configName, config
 
+# create simplified equivalent of above using input rinv
+def fcdc_config_simp(*, common, rinv):
+    configName = 'rinv{:.3f}'.format(rinv).replace('.','p')
+    config = MagiConfig(rinv=rinv)
+    config.join(common)
+    return configName, config
+
 # create spread of fcdc configs for Nc=Nf case
-def fcdc_configs_NcNf1(*, common):
+def fcdc_configs_NcNf1(*, common, simp=False):
     Nf_min = 3
     Nf_max = 8
     Ns_min = 1
@@ -52,7 +66,10 @@ def fcdc_configs_NcNf1(*, common):
     for Nf_val in range(Nf_min,Nf_max+1):
         Ns_max = Nf_val - 2
         for Ns_val in range(Ns_min, Ns_max+1):
-            this_name, this_config = fcdc_config(common=common, Nc=Nf_val, Nf=Nf_val, Ns=Ns_val)
+            if simp:
+                this_name, this_config = fcdc_config_simp(common=common, rinv=fcdc_rinv(Nf=Nf_val, Ns=Ns_val))
+            else:
+                this_name, this_config = fcdc_config(common=common, Nc=Nf_val, Nf=Nf_val, Ns=Ns_val)
             setattr(config, this_name, this_config)
     return config
 
@@ -638,6 +655,8 @@ class svjHelper(baseHelper):
         metadict["darkHadronFinalIDs"] = self.darkHadronFinalIDs
         if self.rinv is not None:
             metadict["rinv"] = self.rinv
+        if self.Ns is not None:
+            metadict["rinv_fcdc"] = fcdc_rinv(Nf=self.Nf, Ns=self.Ns)
         return metadict
 
     def getPythiaSettings(self):

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -89,15 +89,22 @@ def alpha_numeric(*, mrho, mpi, mq):
     def lam(a, b, c):
         return a*a + b*b + c*c - 2.0*(a*b + a*c + b*c)
 
-    def weight_D(s):
-        L1 = lam(mrho*mrho, mpi*mpi, s)
-        L2 = lam(s, mq*mq, mq*mq)
-        return np.sqrt(L1 * L2) / s
-
-    def weight_I1(s):
+    def phase_space(s):
         L1 = lam(mrho*mrho, mpi*mpi, s)
         L2 = lam(s, mq*mq, mq*mq)
         return np.sqrt(L1 * L2)
+
+    # this can be generalized to any weight function
+    # currently just power law
+    s_power = 0
+    def weight(s):
+        return s**s_power
+
+    def weight_D(s):
+        return weight(s) * phase_space(s) / s
+
+    def weight_I1(s):
+        return weight(s) * phase_space(s)
 
     D_val, _ = integrate.quad(weight_D, s_min, s_max, limit=200)
     I1_val, _ = integrate.quad(weight_I1, s_min, s_max, limit=200)
@@ -112,7 +119,8 @@ def alpha_mean(*, mrho, mpi):
     quarks = quarklist()
     quarks.set(mrho - mpi)
     theQuarks = quarks.get()
-    alpha = np.mean([alpha_numeric(mrho=mrho, mpi=mpi, mq=q.mass) for q in theQuarks])
+    alphas = [alpha_numeric(mrho=mrho, mpi=mpi, mq=q.mass) for q in theQuarks]
+    alpha = np.mean(alphas)
     return alpha
 
 def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector):

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -641,8 +641,11 @@ class baseHelper():
         HVEnergyFractions = '\n'.join(["  add EnergyFraction {{{}}} {{0}}".format(id) for id in self.stableIDs])
         stableIDs_with_neg = add_neg(self.stableIDs)
         HVNuFilter = '\n'.join(pdg_lines(stableIDs_with_neg))
+        HVDaughterFilter = HVNuFilter.replace("PdgCode", "PdgDaughter")
         darkHadronIDs_with_neg = add_neg(self.darkHadronIDs)
         HVDarkHadronFilter = '\n'.join(pdg_lines(darkHadronIDs_with_neg))
+        darkHadronFinalIDs_with_neg = add_neg(self.darkHadronFinalIDs)
+        HVDarkHadronFinalFilter = '\n'.join(pdg_lines(darkHadronFinalIDs_with_neg))
 
         with input.open() as infile:
             old_lines = Template(infile.read())
@@ -650,6 +653,8 @@ class baseHelper():
                 HVEnergyFractions = HVEnergyFractions,
                 HVNuFilter = HVNuFilter,
                 HVDarkHadronFilter = HVDarkHadronFilter,
+                HVDaughterFilter = HVDaughterFilter,
+                HVDarkHadronFinalFilter = HVDarkHadronFinalFilter,
             )
         return new_lines
 

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -73,6 +73,71 @@ def fcdc_configs_NcNf1(*, common, simp=False):
             setattr(config, this_name, this_config)
     return config
 
+# 3-body functions
+
+def alpha_numeric(*, mrho, mpi, mq):
+    # numerical computation of alpha = <E_pi>/<E_rho> from 3-body phase-space integrals
+    import numpy as np
+    from scipy import integrate
+
+    s_min = 4.0 * mq * mq
+    s_max = (mrho - mpi)**2
+
+    if s_max <= s_min:
+        return 1.0  # no phase space
+
+    def lam(a, b, c):
+        return a*a + b*b + c*c - 2.0*(a*b + a*c + b*c)
+
+    def weight_D(s):
+        L1 = lam(mrho*mrho, mpi*mpi, s)
+        L2 = lam(s, mq*mq, mq*mq)
+        return np.sqrt(L1 * L2) / s
+
+    def weight_I1(s):
+        L1 = lam(mrho*mrho, mpi*mpi, s)
+        L2 = lam(s, mq*mq, mq*mq)
+        return np.sqrt(L1 * L2)
+
+    D_val, _ = integrate.quad(weight_D, s_min, s_max, limit=200)
+    I1_val, _ = integrate.quad(weight_I1, s_min, s_max, limit=200)
+
+    alpha = (mrho*mrho + mpi*mpi)/(2.0*mrho*mrho) - I1_val/(2.0*mrho*mrho*D_val)
+
+    return alpha
+
+# average alpha over all allowed q qbar decays
+def alpha_mean(*, mrho, mpi):
+    import numpy as np
+    quarks = quarklist()
+    quarks.set(mrho - mpi)
+    theQuarks = quarks.get()
+    alpha = np.mean([alpha_numeric(mrho=mrho, mpi=mpi, mq=q.mass) for q in theQuarks])
+    return alpha
+
+def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector):
+    # off-diagonal pi w/ no FCDC: stable
+    # off-diagonal rho w/ no FCDC: decay to pi q qbar (pi stable)
+    # all others decay to q qbar (mass insertion or democratic)
+
+    Nu = Nf-Ns
+    Nstable = Nf*(Nf-1) - Nu*(Nu-1)
+    Npi = Nf**2-1 # neglect eta prime
+    Nrho = Nf**2
+
+    numer_pi = (1-pvector)*Nstable
+    numer_rho = alpha_mean(mrho=mrho, mpi=mpi)*pvector*Nstable
+    denom_pi = (1-pvector)*Npi
+    denom_rho = pvector*Nrho
+
+    rinv = (numer_pi + numer_rho) / (denom_pi + denom_rho)
+    return rinv
+
+def fcdc_rinv_3body_simp(*, rinv, mrho, mpi, pvector):
+    # simplified model does not use separateFlav: pi and rho have equal frequencies
+    rinv_eff = (1-pvector)*rinv + alpha_mean(mrho=mrho, mpi=mpi)*pvector*rinv
+    return rinv_eff
+
 # classes for helper
 
 class quark(object):
@@ -655,8 +720,12 @@ class svjHelper(baseHelper):
         metadict["darkHadronFinalIDs"] = self.darkHadronFinalIDs
         if self.rinv is not None:
             metadict["rinv"] = self.rinv
+            if self.mrho < 2*self.mpi:
+                metadict["rinv_3body"] = fcdc_rinv_3body_simp(rinv=self.rinv, mrho=self.mrho, mpi=self.mpi, pvector=self.pvector)
         if self.Ns is not None:
-            metadict["rinv_fcdc"] = fcdc_rinv(Nf=self.Nf, Ns=self.Ns)
+            metadict["rinv"] = fcdc_rinv(Nf=self.Nf, Ns=self.Ns)
+            if self.mrho < 2*self.mpi:
+                metadict["rinv_3body"] = fcdc_rinv_3body(Nf=self.Nf, Ns=self.Ns, mrho=self.mrho, mpi=self.mpi, pvector=self.pvector)
         return metadict
 
     def getPythiaSettings(self):

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -133,9 +133,16 @@ def fcdc_rinv_3body(*, Nf, Ns, mrho, mpi, pvector):
     rinv = (numer_pi + numer_rho) / (denom_pi + denom_rho)
     return rinv
 
-def fcdc_rinv_3body_simp(*, rinv, mrho, mpi, pvector):
-    # simplified model does not use separateFlav: pi and rho have equal frequencies
-    rinv_eff = (1-pvector)*rinv + alpha_mean(mrho=mrho, mpi=mpi)*pvector*rinv
+def fcdc_rinv_3body_simp(*, rinv, Nf, mrho, mpi, pvector):
+    Npi = Nf**2-1 # neglect eta prime
+    Nrho = Nf**2
+
+    numer_pi = (1-pvector)*rinv*Npi
+    numer_rho = alpha_mean(mrho=mrho, mpi=mpi)*pvector*rinv*Nrho
+    denom_pi = (1-pvector)*Npi
+    denom_rho = pvector*Nrho
+
+    rinv_eff = (numer_pi + numer_rho) / (denom_pi + denom_rho)
     return rinv_eff
 
 # classes for helper
@@ -424,6 +431,8 @@ class hvSpectrum():
             # define missing antiparticles
             '4900111:antiName = pivDiagbar',
             '4900113:antiName = rhovDiagbar',
+            # disable eta prime production: Nf^2-1 accessible states
+            'HiddenValley:probKeepEta1 = 0',
         ]
 
     # helper for common dark quark/hadron lines in separateFlav setup
@@ -726,7 +735,7 @@ class svjHelper(baseHelper):
         if self.rinv is not None:
             metadict["rinv"] = self.rinv
             if self.mrho < 2*self.mpi:
-                metadict["rinv_3body"] = fcdc_rinv_3body_simp(rinv=self.rinv, mrho=self.mrho, mpi=self.mpi, pvector=self.pvector)
+                metadict["rinv_3body"] = fcdc_rinv_3body_simp(rinv=self.rinv, Nf=self.Nf, mrho=self.mrho, mpi=self.mpi, pvector=self.pvector)
         if self.Ns is not None:
             metadict["rinv"] = fcdc_rinv(Nf=self.Nf, Ns=self.Ns)
             if self.mrho < 2*self.mpi:


### PR DESCRIPTION
1. Install [patched version of Delphes](https://github.com/cms-svj/delphes/tree/DarkHadronJets) with modifications for dark hadron particle selection and dark hadron jet clustering
2. Update Delphes cards to use these modifications to create new collections for dark hadron jets
3. Further streamline `Histogram.py`:
    * avoid duplicating names/titles
    * use `vector` builtin functions
    * avoid repeating calculations / variable extractions for Jets 1 and 2 (do both at once)
4. Improvements to `Histogram.py`:
    * automatically fill histograms for Jet 1, Jet 2, and Jets 1 & 2 together
    * Add metadata dictionary with information from model and from statistics of columns used to fill selected histograms
5. Additional analysis:
    * Dark hadron jet momentum fractions: using four-momentum projection or scalar pT sum (alternative)
        * per-jet, dijet, and global (over all events)
    * Dark hadron jet radius: using scalar pT sum (jet shape)
    * 3-body momentum fraction alpha measurement from Pythia
6. Improvements to `Plot.py`:
    * add line style cycling
    * add output directory option
    * add linear y-axis option
    * set default samples to those used for 3-body rinv study
7. Add `Metaplot.py` to make scatterplots from metadata (model parameters or histogram statistics)
8. Update Delphes mass unit fix to work better with new coffea schema
9. Add various command-line options to `run_fcdc_models.py`
10. Add functions to create simplified equivalents of complete FCDC models, and some configs showing how to use them
11. Add functions to compute various predicted rinv values in different scenarios, including with 3-body momentum fraction from phase space integrals
12. Bug fix for simplified models: apply Pythia setting `probKeepEta1=0`, as done in complete FCDC model

The studies using these changes, comparing different methods of estimating rinv for 2-body and 3-body complete and simplified models, are run as follows:
```bash
(set -x; for CONFIG in configs/model_fcdc_mpi6.py configs/model_snowmass_fcdclike_mpi6.py; do python3 run_fcdc_models.py --config-name ${CONFIG}; done; for CONFIG in configs/model_fcdc_mpi6_3body.py configs/model_snowmass_fcdclike_mpi6_3body.py; do python3 run_fcdc_models.py --config-name ${CONFIG} --suffix 3body; done) >& log_all.log &

python3 Plots.py --dir All_plots_fcdc_mpi6_dhjet --liny rinv

python3 Metaplot.py --xlabel '$r_{\text{inv}}^{\pi}$'
python3 Metaplot.py --dir All_metaplots_2body --samples FCDC simp -x rinv --xlabel '$r_{\text{inv}}^{\pi}$'
python3 Metaplot.py --dir All_metaplots_3body --samples "FCDC (3-body)" "simp (3-body)" -x rinv_3body --xlabel '$r_{\text{inv}}^{\text{3body}}$ or $r_{\text{inv}}^{\text{eff}}$' --offset 2 --types stat
python3 Metaplot.py --dir All_metaplots_3body_forcex --samples "FCDC (3-body)" "simp (3-body)" -x rinv_3body --xlabel '$r_{\text{inv}}^{\text{3body}}$' --offset 2 --forcex "FCDC (3-body)"
python3 Metaplot.py --dir All_metaplots_3body_gen --samples "FCDC (3-body)" "simp (3-body)" -x rinv_3body_gen --xlabel '$r_{\text{inv}}^{\text{3body (gen)}}$ or $r_{\text{inv}}^{\text{eff (gen)}}$' --offset 2 --types stat
python3 Metaplot.py --dir All_metaplots_3body_gen_forcex --samples "FCDC (3-body)" "simp (3-body)" -x rinv_3body_gen --xlabel '$r_{\text{inv}}^{\text{3body (gen)}}$' --offset 2 --forcex "FCDC (3-body)"
```