### PR TITLE
Various upgrades and bug fixes

### DIFF
--- a/Histogram.py
+++ b/Histogram.py
@@ -259,7 +259,7 @@ def fill_stats(array):
         "stderr": sem(nparray),
     }
 
-def histogram(filename, helper, with_constituents=True, debug=False):
+def histogram(filename, helper, with_constituents=True, gen_only=False, debug=False):
     events = load_events(filename, with_constituents=with_constituents)
 
     # output dictionary with histograms and metadata
@@ -267,63 +267,64 @@ def histogram(filename, helper, with_constituents=True, debug=False):
     output["model"] = helper.metadata()
     meta_dict = {}
 
-    # require two jets
-    mask = ak.num(events.FatJet)>=2
-    events = events[mask]
-
-    #get rid of None Events
+    # get rid of None Events
     mask2 = ~ak.is_none(events.Event.Number)
     events = events[mask2]
 
-    # Dijet
-    events["Dijet"] = events.FatJet[:,0]+events.FatJet[:,1]
+    if not gen_only:
+        # require two jets
+        mask = ak.num(events.FatJet)>=2
+        events = events[mask]
 
-    # transverse mass calculation
-    events["MT"] = calc_mt(events.Dijet, events.MissingET)
+        # Dijet
+        events["Dijet"] = events.FatJet[:,0]+events.FatJet[:,1]
 
-    # 4-vectors for dijet
-    events["Dijet_pt"] = events.Dijet.pt
-    events["Dijet_eta"] = events.Dijet.eta
-    events["Dijet_phi"] = events.Dijet.phi
-    events["Dijet_mass"] = events.Dijet.mass
+        # transverse mass calculation
+        events["MT"] = calc_mt(events.Dijet, events.MissingET)
 
-    events["MET"] = events.MissingET.MET
+        # 4-vectors for dijet
+        events["Dijet_pt"] = events.Dijet.pt
+        events["Dijet_eta"] = events.Dijet.eta
+        events["Dijet_phi"] = events.Dijet.phi
+        events["Dijet_mass"] = events.Dijet.mass
 
-    ## For plotting individually for jet1 and jet2
-    events["Jet12"] = ak.pad_none(events.FatJet[:,0:2], target=2, axis=1)
+        events["MET"] = events.MissingET.MET
 
-    # 4-vectors for jet1 and jet2
-    events["Jet12_pt"] = events["Jet12"].pt
-    events["Jet12_eta"] = events["Jet12"].eta
-    events["Jet12_phi"] = events["Jet12"].phi
-    events["Jet12_mass"] = events["Jet12"].mass
+        ## For plotting individually for jet1 and jet2
+        events["Jet12"] = ak.pad_none(events.FatJet[:,0:2], target=2, axis=1)
 
-    events["DeltaEta"] = np.abs(events["Jet12_eta"][:,0] - events["Jet12_eta"][:,1])
-    events["DeltaPhi"] = np.abs(events["Jet12"][:,0].deltaphi(events["Jet12"][:,1]))
+        # 4-vectors for jet1 and jet2
+        events["Jet12_pt"] = events["Jet12"].pt
+        events["Jet12_eta"] = events["Jet12"].eta
+        events["Jet12_phi"] = events["Jet12"].phi
+        events["Jet12_mass"] = events["Jet12"].mass
 
-    events["DeltaPhi_MET_Jet12"] = np.abs(events.MissingET.deltaphi(events["Jet12"]))
+        events["DeltaEta"] = np.abs(events["Jet12_eta"][:,0] - events["Jet12_eta"][:,1])
+        events["DeltaPhi"] = np.abs(events["Jet12"][:,0].deltaphi(events["Jet12"][:,1]))
 
-    # add substructure quantities
-    kt_cuts = [1,2,5,10]
-    n_ecf = [2,3]
-    if with_constituents:
-        events["Jet12_girth"] = calculate_girth(events["Jet12"])
-        events["Jet12_ptD"] = calculate_ptD(events["Jet12"])
-        events["Jet12_majoraxis"], events["Jet12_minoraxis"] = calc_axis1_axis2(events["Jet12"])
+        events["DeltaPhi_MET_Jet12"] = np.abs(events.MissingET.deltaphi(events["Jet12"]))
 
-        # maybe do this in a nicer way, looping is annoying
-        jet12_shape = ak.num(events['Jet12'],axis=1)
-        jet12_flat = ak.flatten(events['Jet12'],axis=1)
-        cs = fj_cluster_sequence(jet12_flat)
-        for k in kt_cuts: 
-            events[f"Jet12_lundMult{k}"] = ak.unflatten(getLundMultiplicity(cs, kt = k), jet12_shape)
-        for n in n_ecf:
-            events[f"Jet12_ECF{n}"] = ak.unflatten(getECF(cs, npointECF = n), jet12_shape)
+        # add substructure quantities
+        kt_cuts = [1,2,5,10]
+        n_ecf = [2,3]
+        if with_constituents:
+            events["Jet12_girth"] = calculate_girth(events["Jet12"])
+            events["Jet12_ptD"] = calculate_ptD(events["Jet12"])
+            events["Jet12_majoraxis"], events["Jet12_minoraxis"] = calc_axis1_axis2(events["Jet12"])
 
-    events["Jet12_sdmass"] = events["Jet12"].SoftDroppedJet.mass
-    events["Jet12_sdpt"] = events["Jet12"].SoftDroppedJet.pt
+            # maybe do this in a nicer way, looping is annoying
+            jet12_shape = ak.num(events['Jet12'],axis=1)
+            jet12_flat = ak.flatten(events['Jet12'],axis=1)
+            cs = fj_cluster_sequence(jet12_flat)
+            for k in kt_cuts:
+                events[f"Jet12_lundMult{k}"] = ak.unflatten(getLundMultiplicity(cs, kt = k), jet12_shape)
+            for n in n_ecf:
+                events[f"Jet12_ECF{n}"] = ak.unflatten(getECF(cs, npointECF = n), jet12_shape)
 
-    events = getTau(events)
+        events["Jet12_sdmass"] = events["Jet12"].SoftDroppedJet.mass
+        events["Jet12_sdpt"] = events["Jet12"].SoftDroppedJet.pt
+
+        events = getTau(events)
 
     # gen-level info
     pid = events.GenParticle["PID"]
@@ -465,42 +466,74 @@ def histogram(filename, helper, with_constituents=True, debug=False):
             return results
 
     # Creating hist objects
-    hist_dict = dict(chain.from_iterable([
-        fill_hist("MT",50,0,mmed*1.5,r"$m_{\text{T}}$ [GeV]"),
-        fill_hist("Dijet_pt",50,0,mmed*0.75,r"$p_{\text{T}}(JJ)$ [GeV]"),
-        fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
-        fill_hist("Dijet_phi",25,-3.15,3.15,r"$\phi(JJ)$"),
-        fill_hist("Dijet_mass",50,0,mmed*1.5,r"$m_{JJ}$ [GeV]"),
-        fill_hist("Jet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND})$ [GeV]"),
-        fill_hist("Jet12_eta",50,-6,6,r"$\eta(J_{JETIND})$"),
-        fill_hist("Jet12_phi",25,-3.15,3.15,r"$\phi(J_{JETIND})$"),
-        fill_hist("Jet12_mass",50,0,250,r"$m_{J_{JETIND}}$ [GeV]"),
-        fill_hist("MET",50,0,mmed*0.75,r"$p_{\text{T}}^{\text{miss}}$ [GeV]"),
-        fill_hist("DeltaEta",35,0,8.0,r"$\Delta\eta(JJ)$"),
-        fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
-        fill_hist("DeltaPhi_MET_Jet12",25,0,3.15,r"$\Delta\phi(J_{JETIND},p_{\text{T}}^{\text{miss}})$"),
+    hist_dict = {}
+
+    # reco-level histograms
+    if not gen_only:
+        hist_dict.update(chain.from_iterable([
+            fill_hist("MT",50,0,mmed*1.5,r"$m_{\text{T}}$ [GeV]"),
+            fill_hist("Dijet_pt",50,0,mmed*0.75,r"$p_{\text{T}}(JJ)$ [GeV]"),
+            fill_hist("Dijet_eta",50,-10,10,r"$\eta(JJ)$ [GeV]"),
+            fill_hist("Dijet_phi",25,-3.15,3.15,r"$\phi(JJ)$"),
+            fill_hist("Dijet_mass",50,0,mmed*1.5,r"$m_{JJ}$ [GeV]"),
+            fill_hist("Jet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND})$ [GeV]"),
+            fill_hist("Jet12_eta",50,-6,6,r"$\eta(J_{JETIND})$"),
+            fill_hist("Jet12_phi",25,-3.15,3.15,r"$\phi(J_{JETIND})$"),
+            fill_hist("Jet12_mass",50,0,250,r"$m_{J_{JETIND}}$ [GeV]"),
+            fill_hist("MET",50,0,mmed*0.75,r"$p_{\text{T}}^{\text{miss}}$ [GeV]"),
+            fill_hist("DeltaEta",35,0,8.0,r"$\Delta\eta(JJ)$"),
+            fill_hist("DeltaPhi",20,0,3.15,r"$\Delta\phi(JJ)$"),
+            fill_hist("DeltaPhi_MET_Jet12",25,0,3.15,r"$\Delta\phi(J_{JETIND},p_{\text{T}}^{\text{miss}})$"),
+            fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
+            fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
+        ]))
+        if with_constituents:
+            hist_dict.update(chain.from_iterable([
+                fill_hist("Jet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND})$"),
+                fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
+                fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
+                fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
+            ]))
+            for k in kt_cuts:
+                label = f'Primary Lund Multiplicity $k_T$>{k} GeV$'
+                hist_dict.update(chain.from_iterable([
+                    fill_hist(f'Jet12_lundMult{k}',12,0,12,label)
+                ]))
+            for n in n_ecf:
+                label = f'$C_{n}^{{\\beta=1}}$'
+                hist_dict.update(chain.from_iterable([
+                    fill_hist(f'Jet12_ECF{n}',30,0,0.3,label)
+                ]))
+
+        for t in events.fields:
+            if 'tau' not in t: continue
+            l = t.split('_')
+            label = l[1].replace('tau', '$\\tau_{')+','+l[0].replace('et12', '_{JETIND}')+'}$'
+            hist_dict.update(chain.from_iterable([
+                fill_hist(t,40,0,1,label)
+            ]))
+
+    # gen-level histograms
+
+    hist_dict.update(chain.from_iterable([
+        fill_hist("stable_invisible_fraction",25,0,1,r"$r_{\text{inv}}^{\text{gen}}$"),
+        fill_hist("alpha_3body",50,0,1,r"$\alpha_{\text{3body}}$"),
+        fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
+        fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
+        fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
+        fill_hist("DHIVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{stable}})$ [GeV]"),
+        fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{DH}}J^{\text{DH}}}$ [GeV]"),
+        fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
+        fill_hist("DiDHIVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{stable}}J^{\text{stable}}}$ [GeV]"),
     ]))
     if with_constituents:
         hist_dict.update(chain.from_iterable([
-            fill_hist("Jet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND})$"),
-            fill_hist("Jet12_ptD",50,0,1.01,r"$D_{p_{\text{T}}}(J_{JETIND})$"),
-            fill_hist("Jet12_majoraxis",50,0,0.5,r"$\sigma_{\text{major}}(J_{JETIND})$"),
-            fill_hist("Jet12_minoraxis",50,0,0.5,r"$\sigma_{\text{minor}}(J_{JETIND})$"),
             fill_hist("DHIVJet12_rinv_proj",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J_{JETIND}^{\text{stable}})$"),
             fill_hist("DiDHIVJet_rinv_proj",25,0,1,r"$r_{\text{inv}}^{\text{kin}}(J^{\text{stable}}J^{\text{stable}})$"),
             fill_hist("DHIVJet12_rinv_shape",25,0,1,r"$r_{\text{inv}}^{\text{kin(alt)}}(J_{JETIND}^{\text{stable}})$"),
             fill_hist("DiDHIVJet_rinv_shape",25,0,1,r"$r_{\text{inv}}^{\text{kin(alt)}}(J^{\text{stable}}J^{\text{stable}})$"),
         ]))
-        for k in kt_cuts: 
-            label = f'Primary Lund Multiplicity $k_T$>{k} GeV$'
-            hist_dict.update(chain.from_iterable([
-                fill_hist(f'Jet12_lundMult{k}',12,0,12,label)
-            ]))    
-        for n in n_ecf:
-            label = f'$C_{n}^{{\\beta=1}}$'
-            hist_dict.update(chain.from_iterable([
-                fill_hist(f'Jet12_ECF{n}',30,0,0.3,label)
-            ]))
 
         dhj_labels = ["DH", "vis", "stable"]
         dhj_nmax = [24.5, 199.5, 199.5]
@@ -513,28 +546,6 @@ def histogram(filename, helper, with_constituents=True, debug=False):
                 fill_hist(f"{pre}Jet12_girth",50,0,1,r"$g_{\text{jet}}(J_{JETIND}^{\text{"+label+"}})$"),
                 fill_hist(f"{pre}Jet12_nconst",nbin,-0.5,nmax,r"$n_{\text{const}}(J_{JETIND}^{\text{"+label+"}})$"),
             ]))
-    hist_dict.update(chain.from_iterable([
-        fill_hist("Jet12_sdmass",50,0,150,r"$m_{\text{SD}}(J_{JETIND})$ [GeV]"),
-        fill_hist("Jet12_sdpt",50,0,mmed*0.75,r"$p^{\text{SD}}_{\text{T}}(J_{JETIND})$ [GeV]"),
-        fill_hist("stable_invisible_fraction",25,0,1,r"$r_{\text{inv}}^{\text{gen}}$"),
-        fill_hist("alpha_3body",50,0,1,r"$\alpha_{\text{3body}}$"),
-        fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
-        fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
-        fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
-        fill_hist("DHIVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{stable}})$ [GeV]"),
-        fill_hist("DiDHJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{DH}}J^{\text{DH}}}$ [GeV]"),
-        fill_hist("DiDHVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
-        fill_hist("DiDHVJet_MT",50,0,mmed*1.5,r"$m_{\text{T}}^{J^{\text{vis}}J^{\text{vis}}}$ [GeV]"),
-        fill_hist("DiDHIVJet_mass",50,0,mmed*1.5,r"$m_{J^{\text{stable}}J^{\text{stable}}}$ [GeV]"),
-    ]))
-
-    for t in events.fields:
-        if 'tau' not in t: continue
-        l = t.split('_')
-        label = l[1].replace('tau', '$\\tau_{')+','+l[0].replace('et12', '_{JETIND}')+'}$'
-        hist_dict.update(chain.from_iterable([
-            fill_hist(t,40,0,1,label)
-        ]))
 
     # finish output dictionary
     output["hist"] = hist_dict

--- a/Histogram.py
+++ b/Histogram.py
@@ -199,6 +199,7 @@ def calc_rinv(events, helper, meta_dict, debug):
         events["alpha_3body"] = alpha_3body
     else:
         events["alpha_3body"] = ak.Array([0])
+        meta_dict["alpha_3body"] = fill_stats(events["alpha_3body"])
 
     is_dark_final = is_dark_final & ~dark_mother_sm_sibling
     printer('is_dark_final',is_dark_final)
@@ -561,7 +562,7 @@ def histogram(filename, helper, with_constituents=True, gen_only=False, debug=Fa
     if helper.mrho < 2*helper.mpi:
         from svjHelper import fcdc_rinv_3body, fcdc_rinv_3body_simp
         if helper.Ns is not None:
-            output["model"]['rinv_3body_gen'] = fcdc_rinv_3body(Nf=helper.Nf, Ns=helper.Ns, mrho=helper.mrho, mpi=helper.mpi, pvector=helper.pvector, alpha=meta_dict['alpha_3body']['mean'])
+            output["model"]['rinvpred_3body_gen'] = fcdc_rinv_3body(Nf=helper.Nf, Ns=helper.Ns, mrho=helper.mrho, mpi=helper.mpi, pvector=helper.pvector, alpha=meta_dict['alpha_3body']['mean'])
         else:
             output["model"]['rinv_3body_gen'] = fcdc_rinv_3body_simp(rinv=helper.rinv, Nf=helper.Nf, mrho=helper.mrho, mpi=helper.mpi, pvector=helper.pvector, alpha=meta_dict['alpha_3body']['mean'])
 

--- a/Histogram.py
+++ b/Histogram.py
@@ -346,11 +346,12 @@ def histogram(filename, helper, with_constituents=True, gen_only=False, debug=Fa
     print(f"Predicted rinv = {output['model'].get('rinv_3body', output.get('rinvpred_3body', output['model'].get('rinv',output['model'].get('rinvpred', -1)))):.5}")
     calc_rinv(events, helper, meta_dict, debug)
 
-    # dark hadron jets and corresponding visible and invisible+visible jets
+    # dark parton/hadron jets and corresponding visible and invisible+visible jets
+    events["DPJet12"] = ak.pad_none(events.DarkPartonJet[:,0:2], target=2, axis=1)
     events["DHJet12"] = ak.pad_none(events.DarkHadronJet[:,0:2], target=2, axis=1)
     events["DHVJet12"] = ak.pad_none(events.DarkHadronVisibleJet[:,0:2], target=2, axis=1)
     events["DHIVJet12"] = ak.pad_none(events.DarkHadronStableJet[:,0:2], target=2, axis=1)
-    dhj_pre = ["DH", "DHV", "DHIV"]
+    dhj_pre = ["DP", "DH", "DHV", "DHIV"]
     jet_inds = [0, 1, slice(0, 2)]
     jet_ind_names = ["1","2","1,2"]
     jet_ind_keys = ["1","2","12"]
@@ -427,7 +428,11 @@ def histogram(filename, helper, with_constituents=True, gen_only=False, debug=Fa
                     [f"{meta_dict[f'DHJet{key}_radius{pct}']['mean']:.2} ({meta_dict[f'DHJet{key}_radius{pct}']['stdev']:.2})" for key in jet_ind_keys]
                 ))
 
-    # dark hadron jet mass and pt
+    # dark parton/hadron jet mass and pt
+    events["DPJet12_pt"] = events["DPJet12"].pt
+    events["DiDPJet"] = events["DPJet12"][:,0] + events["DPJet12"][:,1]
+    events["DiDPJet_mass"] = events["DiDPJet"].mass
+
     events["DHJet12_pt"] = events["DHJet12"].pt
     events["DiDHJet"] = events["DHJet12"][:,0] + events["DHJet12"][:,1]
     events["DiDHJet_mass"] = events["DiDHJet"].mass
@@ -519,6 +524,7 @@ def histogram(filename, helper, with_constituents=True, gen_only=False, debug=Fa
         fill_hist("stable_invisible_fraction",25,0,1,r"$r_{\text{inv}}^{\text{gen}}$"),
         fill_hist("alpha_3body",50,0,1,r"$\alpha_{\text{3body}}$"),
         fill_hist("mMediator",50,0,mmed*1.5,r"$m_{\text{mediator}}$ [GeV]"),
+        fill_hist("DPJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DP}})$ [GeV]"),
         fill_hist("DHJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{DH}})$ [GeV]"),
         fill_hist("DHVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{vis}})$ [GeV]"),
         fill_hist("DHIVJet12_pt",50,0,mmed*0.75,r"$p_{\text{T}}(J_{JETIND}^{\text{stable}})$ [GeV]"),
@@ -535,9 +541,9 @@ def histogram(filename, helper, with_constituents=True, gen_only=False, debug=Fa
             fill_hist("DiDHIVJet_rinv_shape",25,0,1,r"$r_{\text{inv}}^{\text{kin(alt)}}(J^{\text{stable}}J^{\text{stable}})$"),
         ]))
 
-        dhj_labels = ["DH", "vis", "stable"]
-        dhj_nmax = [24.5, 199.5, 199.5]
-        dhj_nbin = [25, 50, 50]
+        dhj_labels = ["DP", "DH", "vis", "stable"]
+        dhj_nmax = [24.5, 24.5, 199.5, 199.5]
+        dhj_nbin = [25, 25, 50, 50]
         for pre,label,nmax,nbin in zip(dhj_pre, dhj_labels,dhj_nmax,dhj_nbin):
             hist_dict.update(chain.from_iterable([
                 fill_hist(f"{pre}Jet12_radius90",50,0,2,r"${\Delta}R_{90}(J_{JETIND}^{\text{"+label+"}})$"),

--- a/Histogram.py
+++ b/Histogram.py
@@ -187,15 +187,18 @@ def calc_rinv(events, helper, meta_dict, debug):
 
     # quick diversion here to measure alpha = E_pi / m_rho for 3-body decays
     is_dark_3body = is_dark_final & dark_mother_sm_sibling
-    pi_3body = events.GenParticle[is_dark_3body]
-    rho_3body = events.GenParticle[m1[is_dark_3body]]
-    pi_3body_restframe = pi_3body.boostCM_of_beta3(rho_3body.to_beta3())
-    E_pi_3body = pi_3body_restframe.energy
-    m_rho_3body = rho_3body.mass
-    alpha_3body = E_pi_3body/m_rho_3body
-    meta_dict["alpha_3body"] = fill_stats(alpha_3body)
-    print(f"Average alpha_3body = {meta_dict['alpha_3body']['mean']:.3} ({meta_dict['alpha_3body']['stdev']:.3})")
-    events["alpha_3body"] = alpha_3body
+    if ak.any(is_dark_3body):
+        pi_3body = events.GenParticle[is_dark_3body]
+        rho_3body = events.GenParticle[m1[is_dark_3body]]
+        pi_3body_restframe = pi_3body.boostCM_of_beta3(rho_3body.to_beta3())
+        E_pi_3body = pi_3body_restframe.energy
+        m_rho_3body = rho_3body.mass
+        alpha_3body = E_pi_3body/m_rho_3body
+        meta_dict["alpha_3body"] = fill_stats(alpha_3body)
+        print(f"Average alpha_3body = {meta_dict['alpha_3body']['mean']:.3} ({meta_dict['alpha_3body']['stdev']:.3})")
+        events["alpha_3body"] = alpha_3body
+    else:
+        events["alpha_3body"] = ak.Array([0])
 
     is_dark_final = is_dark_final & ~dark_mother_sm_sibling
     printer('is_dark_final',is_dark_final)

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -137,7 +137,10 @@ def make_plot(type, data, x, xlabel, qname, outdir, offset):
     plt.close(fig)
 
 def make_all_plots(outdir, types, sample_list, x, y, xlabel, forcex, offset):
-    data = accumulate_data(sample_list)
+    selected_samples = samples
+    if sample_list:
+        selected_samples = [sample for sample in samples if sample["name" in sample_list]
+    data = accumulate_data(selected_samples)
 
     os.makedirs(outdir, exist_ok=True)
     for qname in y:

--- a/Metaplot.py
+++ b/Metaplot.py
@@ -26,10 +26,16 @@ for sample in samples:
 
 custom_cycler = set_plot_style()
 
+def get_xvals(x, meta):
+    # account for difference between complete and simplified models
+    if "rinvpred" in x and x not in meta:
+        return meta[x.replace("rinvpred","rinv")]
+    return meta[x]
+
 def process_data(data, x, qname, forcex):
     processed = []
     for sample, models in data.items():
-        xvals = np.array([model['meta'][x] for model in models])
+        xvals = np.array([get_xvals(x,model['meta']) for model in models])
         means, stdevs, stderrs, hists = zip(*[
             (model['meta'][qname]['mean'], model['meta'][qname]['stdev'], model['meta'][qname]['stderr'], model['hist'].get(qname,None)) for model in models
         ])
@@ -139,7 +145,7 @@ def make_plot(type, data, x, xlabel, qname, outdir, offset):
 def make_all_plots(outdir, types, sample_list, x, y, xlabel, forcex, offset):
     selected_samples = samples
     if sample_list:
-        selected_samples = [sample for sample in samples if sample["name" in sample_list]
+        selected_samples = [sample for sample in samples if sample["name"] in sample_list]
     data = accumulate_data(selected_samples)
 
     os.makedirs(outdir, exist_ok=True)
@@ -167,7 +173,7 @@ if __name__=="__main__":
     parser.add_argument("--dir", type=str, default="All_metaplots", help="output directory")
     parser.add_argument("--types", type=str, default=allowed_types, nargs='*', choices=allowed_types, help="plot types")
     parser.add_argument("--samples", type=str, default=[], nargs='*', help="list of samples to plot")
-    parser.add_argument("-x", type=str, default='rinv', help="x variable")
+    parser.add_argument("-x", type=str, default='rinvpred', help="x variable")
     parser.add_argument("--xlabel", type=str, default=None, help="x axis label")
     parser.add_argument("--forcex", type=str, default=None, help="force use of x values from specified sample")
     parser.add_argument("-y", type=str, default=qtys_default, nargs='*', help="y variable(s)")

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ cd model_building
 ./install.sh
 ```
 
+The default version of Pythia is currently 8.310.
+To install a different version of Pythia, specify the desired minor version, e.g.:
+```bash
+./install.sh -p 17
+```
+
 ## Environment
 
 ```bash
@@ -16,19 +22,24 @@ source init.sh
 
 This repository is built on the [LCG 106](https://lcginfo.cern.ch/release_packages/106/x86_64-el9-gcc13-opt/) environment.
 Important software versions:
+* Python 3.11.9
 * Pythia8 3.10
 * Delphes 3.5.1 (patched)
-* HepMC 2.06.11
+* HepMC 3.2.7
 * ROOT 6.32.02
+* numpy 1.26.4
 * coffea 2025.12.0
-* uproot 5.7.2
-* awkward 2.9.0
+* uproot 5.7.5
+* awkward 2.10.0
+* matplotlib 3.11.0
+* mplhep 1.3.2
 
 ## Predefined model configurations
 
 A few predefined model configuration files are provided in the [configs](./configs) folder:
 1. The CMS model used in [EXO-19-020](https://arxiv.org/abs/2112.11125) (largely based on [arXiv:1503.00009](https://www.arxiv.org/abs/1503.00009) and [arXiv:1707.05326](https://arxiv.org/abs/1707.05326)).
 2. One of the Snowmass benchmark models from [arXiv:2203.09503](https://arxiv.org/abs/2203.09503).
+3. The new flavor-changing dark current (FCDC) model, in both complete and simplified versions.
 
 ## Running
 

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -41,6 +41,8 @@ set ExecutionPath {
   GenJetFinder
   GenFatJetFinder
   GenMissingET
+  DarkPartonFilter
+  DarkPartonJetFinder
   DarkHadronFilter
   DarkHadronJetFinder
   DarkHadronVisibleJetFinder
@@ -676,6 +678,55 @@ module Merger GenMissingET {
 }
 
 ####################
+# Dark parton finder
+####################
+
+module PdgCodeFilter DarkPartonFilter {
+
+  set InputArray Delphes/allParticles
+  set OutputArray filteredParticles
+
+  set PTMin 0.0
+  set LastDark 1
+  set Invert 1
+
+  add PdgCode 4900101
+  add PdgCode 4900102
+  add PdgCode 4900103
+  add PdgCode 4900104
+  add PdgCode 4900105
+  add PdgCode 4900106
+  add PdgCode 4900107
+  add PdgCode 4900108
+  add PdgCode 4900021
+}
+
+############################
+# Dark parton jet clustering
+############################
+
+module FastJetFinder DarkPartonJetFinder {
+  set InputArray DarkPartonFilter/filteredParticles
+
+  set OutputArray jets
+
+  # algorithm: 1 CDFJetClu, 2 MidPoint, 3 SIScone, 4 kt, 5 Cambridge/Aachen, 6 antikt
+  set JetAlgorithm 6
+  set ParameterR 0.8
+
+  set ComputeNsubjettiness 1
+  set Beta 1.0
+  set AxisMode 4
+
+  set ComputeSoftDrop 1
+  set BetaSoftDrop 0.0
+  set SymmetryCutSoftDrop 0.1
+  set R0SoftDrop 0.8
+
+  set JetPTMin 15.0
+}
+
+####################
 # Dark hadron finder
 ####################
 
@@ -961,7 +1012,9 @@ module TreeWriter TreeWriter {
   add Branch GenFatJetFinder/jets GenFatJet Jet
   add Branch GenMissingET/momentum GenMissingET MissingET
 
-  # dark hadron jet collections
+  # dark parton & hadron jet collections
+  add Branch DarkPartonFilter/filteredParticles DarkPartonCandidate GenParticle
+  add Branch DarkPartonJetFinder/jets DarkPartonJet Jet
   add Branch DarkHadronFilter/filteredParticles DarkHadronCandidate GenParticle
   add Branch DarkHadronJetFinder/jets DarkHadronJet Jet
   add Branch DarkHadronVisibleJetFinder/jets DarkHadronVisibleJet Jet

--- a/cards/no_HVfragment.txt
+++ b/cards/no_HVfragment.txt
@@ -1,0 +1,1 @@
+HiddenValley:fragment = off

--- a/common.py
+++ b/common.py
@@ -11,6 +11,7 @@ import fnmatch
 import shutil
 from glob import glob
 from XRootD import client as xrootd_client
+import pickle
 
 DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",

--- a/common.py
+++ b/common.py
@@ -14,12 +14,14 @@ from XRootD import client as xrootd_client
 
 DelphesSchema.mixins.update({
     "ParticleFlowCandidate": "Particle",
+    "DarkPartonCandidate": "Particle",
     "DarkHadronCandidate": "Particle",
     "GenCandidate": "Particle",
     "GenStableCandidate": "Particle",
     "GenParticle": "Particle",
     "FatJet": "Jet",
     "GenFatJet": "Jet",
+    "DarkPartonJet": "Jet",
     "DarkHadronJet": "Jet",
     "DarkHadronVisibleJet": "Jet",
     "DarkHadronStableJet": "Jet",
@@ -32,6 +34,7 @@ def fix_delphes_mass_units(events):
         "GenParticle",
         "GenCandidate",
         "GenStableCandidate",
+        "DarkPartonCandidate",
         "DarkHadronCandidate",
     ]
     for col in GenParticleCollections:
@@ -42,6 +45,7 @@ class DelphesSchema2(DelphesSchema):
     jet_const_pairs = {
         "FatJet" : "ParticleFlowCandidate",
         "Jet" : "ParticleFlowCandidate",
+        "DarkPartonJet" : "DarkPartonCandidate",
         "DarkHadronJet" : "DarkHadronCandidate",
         "DarkHadronVisibleJet": "GenCandidate",
         "DarkHadronStableJet": "GenStableCandidate",

--- a/common.py
+++ b/common.py
@@ -121,6 +121,8 @@ def get_constituents_chunk(events, jetsname, candsname):
     gathered = flat_cands[flat_indices]
 
     # rebuild structure (one level at a time)
+    counts_all = np.asarray(counts_all, dtype=np.int64)
+    jets_per_event = np.asarray(jets_per_event, dtype=np.int64)
     jets_level = ak.unflatten(gathered, counts_all)
     events_level = ak.unflatten(jets_level, jets_per_event)
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,13 @@
 
 source init.sh
 
+while getopts "p:" opt; do
+	case "$opt" in
+		p) export PYTHIA8MINOR="$OPTARG"
+		;;
+	esac
+done
+
 cd install
 
 for EXTERNAL in $MODEL_BUILDING_EXTERNALS; do

--- a/install/pythia8.sh
+++ b/install/pythia8.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-PYTHIA_VERSION=pythia8310
+if [ -z "PYTHIA8MINOR" ]; then
+	export PYTHIA8MINOR=10
+fi
+
+PYTHIA_VERSION=pythia83${PYTHIA8MINOR}
+PYTHIA_EXE=main42
+if [ "$PYTHIA8MINOR" -ge 12 ]; then
+	PYTHIA_EXE=main132
+fi
 
 wget "https://pythia.org/releases/pythia83/${PYTHIA_VERSION}.tgz"
 tar -xzf ${PYTHIA_VERSION}.tgz
@@ -16,7 +24,7 @@ make -j 8
 make install
 
 (cd examples
-make main42
+make ${PYTHIA_EXE}
 )
 
 cat << 'EOF' > mb_init.sh
@@ -24,5 +32,6 @@ export PYTHIA8=${MODEL_BUILDING}/install/pythia8
 export PATH=${PYTHIA8}/bin/:${PATH}
 export LD_LIBRARY_PATH=${PYTHIA8}/lib/:${LD_LIBRARY_PATH}
 export PYTHIA8DATA=$(pythia8-config --xmldoc)
-export PYTHIA8RUNNER=${PYTHIA8}/examples/main42
+export PYTHIA8MINOR=${PYTHIA8MINOR}
+export PYTHIA8RUNNER=${PYTHIA8}/examples/${PYTHIA_EXE}
 EOF

--- a/install/pythia8.sh
+++ b/install/pythia8.sh
@@ -2,7 +2,7 @@
 
 PYTHIA_VERSION=pythia8310
 
-wget "https://www.pythia.org/download/pythia83/${PYTHIA_VERSION}.tgz"
+wget "https://pythia.org/releases/pythia83/${PYTHIA_VERSION}.tgz"
 tar -xzf ${PYTHIA_VERSION}.tgz
 mv ${PYTHIA_VERSION} pythia8
 rm ${PYTHIA_VERSION}.tgz

--- a/install/pythia8.sh
+++ b/install/pythia8.sh
@@ -16,10 +16,10 @@ mv ${PYTHIA_VERSION} pythia8
 rm ${PYTHIA_VERSION}.tgz
 cd pythia8
 
-HEPMC_BASE=(/cvmfs/sft.cern.ch/lcg/releases/${LCG_VIEW}/HepMC/*/${LCG_ARCH})
+HEPMC_BASE=(/cvmfs/sft.cern.ch/lcg/releases/${LCG_VIEW}/hepmc3/*/${LCG_ARCH})
 LHAPDF_BASE=(/cvmfs/sft.cern.ch/lcg/releases/${LCG_VIEW}/MCGenerators/lhapdf/*/${LCG_ARCH})
 
-./configure --with-hepmc2=${HEPMC_BASE} --with-lhapdf6=${LHAPDF_BASE} --with-python --with-gzip
+./configure --with-hepmc3=${HEPMC_BASE} --with-hepmc3-lib=${HEPMC_BASE}/lib64 --with-lhapdf6=${LHAPDF_BASE} --with-python --with-gzip
 make -j 8
 make install
 

--- a/install/python_packages.sh
+++ b/install/python_packages.sh
@@ -3,13 +3,23 @@
 mkdir -p python_packages
 cd python_packages
 
+wget https://github.com/kpedro88/lcg-venv/raw/refs/heads/main/lcg-venv
+chmod +x lcg-venv
+./lcg-venv mbenv
+
+cat << 'EOF' > mb_init.sh
+source ${MODEL_BUILDING}/install/python_packages/mbenv/bin/activate
+EOF
+
+source mb_init.sh
+
 PKGS_UPGRADE=(
 coffea==2025.12.0 \
 mplhep \
 )
 
 for PKG in ${PKGS_UPGRADE[@]}; do
-	HOME=$PWD pip install --user --no-cache-dir --upgrade $PKG
+	pip install --upgrade $PKG
 done
 
 PKGS=(
@@ -18,9 +28,5 @@ fastjet \
 )
 
 for PKG in ${PKGS[@]}; do
-	HOME=$PWD pip install --user --no-cache-dir $PKG
+	pip install $PKG
 done
-
-cat << 'EOF' > mb_init.sh
-export PYTHONPATH=${MODEL_BUILDING}/install/python_packages/.local/lib/python3.11/site-packages/:${PYTHONPATH}
-EOF

--- a/run_fcdc_models.py
+++ b/run_fcdc_models.py
@@ -1,20 +1,35 @@
 import os, sys, imp
 from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
+from multiprocessing import Pool
 
 config_dir = os.path.join(os.getcwd(), "configs")
-sys.path.append(config_dir)
+if config_dir not in sys.path:
+    sys.path.append(config_dir)
 
-def run_objs(config_name, args, suffix, outdir, dryrun):
+def run_objs(config_name, args, suffix, outdir, nproc, dryrun):
+    os.makedirs(outdir, exist_ok=True)
     configs_fcdc = imp.load_source("configs_fcdc", config_name)
     objs = [obj for obj in vars(configs_fcdc.config)]
 
+    cmds = []
     for obj in objs:
         logName = f'model_{obj}'
         if suffix: logName += f'_{suffix}'
-        print(obj)
         cmd = f'./run_model helper -C {config_name} -O config.{obj} --dir {outdir} {args} > {outdir}/{logName}.log'
+        cmds.append(cmd)
+
+    for (obj,cmd) in zip(objs,cmds):
+        print(obj)
         print(cmd)
-        if not dryrun: os.system(cmd)
+        # serial processing
+        if not dryrun and nproc<=1:
+            os.system(cmd)
+
+    # parallel processing
+    if not dryrun and nproc>1:
+        with Pool(nproc) as pool:
+            exit_codes = pool.map(os.system, cmds)
+        print(f"Exit codes: {exit_codes}")
 
 if __name__=="__main__":
     parser = ArgumentParser(
@@ -24,6 +39,7 @@ if __name__=="__main__":
     parser.add_argument("--args", type=str, default="--steps all --events 1000 --verbose", help="arguments to pass to run_model")
     parser.add_argument("--suffix", type=str, default="", help="suffix for log file names")
     parser.add_argument("--outdir", type=str, default="models/fcdc/", help="outdir for logfile and events")
+    parser.add_argument("--nproc", type=int, default=1, help="run in parallel (if > 1)")
     parser.add_argument("--dryrun", default=False, action="store_true", help="print commands but don't run")
     args = parser.parse_args()
-    run_objs(args.config_name, args.args, args.suffix, args.outdir, args.dryrun)
+    run_objs(args.config_name, args.args, args.suffix, args.outdir, args.nproc, args.dryrun)

--- a/run_model
+++ b/run_model
@@ -24,6 +24,27 @@ def run_cmd(cmd,log,verbose=False,shell=False):
             cmd = shlex.split(cmd)
         subprocess.check_call(cmd,stdout=logfile,stderr=logfile,shell=shell)
 
+# minimal sed-like function
+# patterns = [(in,out),(in,out)]
+# currently doesn't handle regex
+def pysed(line, patterns):
+    for pattern,replace in patterns.items():
+        line = line.replace(pattern,replace)
+    return line
+
+def pythia_handlers():
+    pythia_version = int(os.getenv("PYTHIA8MINOR"))
+    arg_string = '{pythia_exe} {pythia_fname} {hepmc_fname}'
+    if pythia_version >= 13:
+        arg_string = '{pythia_exe} -c {pythia_fname} -o {hepmc_fname}'
+    card_formatter = lambda line: line
+    if pythia_version >= 13:
+        replacements = [
+            ("ParticleDecays:allowPhotonRadiation = on", "HadronLevel:QED = on")
+        ]
+        card_formatter = lambda line: pysed(line, replacements)
+    return {"arg_string": arg_string, "card_formatter": card_formatter}
+
 if __name__=="__main__":
     _parser_common = ArgumentParser(add_help=False)
 
@@ -87,6 +108,7 @@ if __name__=="__main__":
     if args["common"].verbose: print(f'wrote {config_fname}')
 
     pythia_lines = helper.getPythiaSettings()
+    pythia_helpers = pythia_handlers()
     if 'pythia' in args["common"].steps:
         pythia_lines.append('Main:numberOfEvents = {}'.format(args["common"].events))
     pythia_fname = "pythia_card.txt"
@@ -95,7 +117,7 @@ if __name__=="__main__":
         file.write('\n')
         if inputs is not None:
             for line in inputs:
-                file.write(line)
+                file.write(pythia_helpers["card_formatter"](line))
     if args["common"].verbose: print(f'wrote {pythia_fname}')
 
     delphes_lines = helper.getDelphesSettings(args["common"].delphes)
@@ -113,7 +135,7 @@ if __name__=="__main__":
         # step 1: pythia
         log_fname = "log_pythia8.log"
         pythia_exe = os.path.expandvars("$PYTHIA8RUNNER")
-        pythia_cmd = f'{pythia_exe} {pythia_fname} {hepmc_fname}'
+        pythia_cmd = pythia_helpers["arg_string"].format(pythia_exe=pythia_exe, pythia_fname=pythia_fname, hepmc_fname=hepmc_fname)
         if not args["common"].quiet: print(f'Running Pythia ({log_fname})')
         run_cmd(pythia_cmd, log_fname, args["common"].verbose)
 
@@ -132,7 +154,7 @@ if __name__=="__main__":
         # step 2: delphes
         log_fname = "log_delphes.log"
         delphes_exe = "DelphesHepMC2"
-        
+
         if os.path.exists(root_fname):
             if args["common"].verbose: print(f'removing old {root_fname}')
             os.remove(root_fname)
@@ -140,8 +162,8 @@ if __name__=="__main__":
         if not args["common"].quiet: print(f'Running Delphes ({log_fname})')
         run_cmd(delphes_cmd, log_fname, args["common"].verbose, shell=True)
         if args["common"].verbose: print(f'wrote {root_fname}')
-        
+
     if 'hist' in args["common"].steps:
-        
+
         Histogram.histogram(root_fname, helper, not args["common"].no_constituents, args["common"].debug)
         if args["common"].verbose: print(f'wrote histograms of {root_fname}')

--- a/run_model
+++ b/run_model
@@ -153,7 +153,7 @@ if __name__=="__main__":
 
         # step 2: delphes
         log_fname = "log_delphes.log"
-        delphes_exe = "DelphesHepMC2"
+        delphes_exe = "DelphesHepMC3"
 
         if os.path.exists(root_fname):
             if args["common"].verbose: print(f'removing old {root_fname}')

--- a/run_model
+++ b/run_model
@@ -73,7 +73,12 @@ if __name__=="__main__":
     parsers = {}
     model_groups = {}
     for model_type in helpers.keys():
-        parsers[model_type] = subparsers.add_parser(model_type, config_options=MagiConfigOptions(obj_args = ['-O', '--obj']), parents=[_parser_common])
+        parsers[model_type] = subparsers.add_parser(
+            model_type,
+            config_options=MagiConfigOptions(obj_args = ['-O', '--obj']),
+            parents=[_parser_common],
+            formatter_class=ArgumentDefaultsRawHelpFormatter,
+        )
         model_groups[model_type] = parsers[model_type].add_argument_group("model")
         helpers[model_type].add_arguments(model_groups[model_type])
         parsers[model_type].set_defaults(model_type=model_type)

--- a/run_model
+++ b/run_model
@@ -60,6 +60,7 @@ if __name__=="__main__":
     common.add_argument("--pythia", type=str, nargs='*', default=["cards/CMS_Common.txt","cards/CMS_Tune_CP5.txt"], help="additional settings for Pythia")
     common.add_argument("--delphes", type=str, default="cards/delphes_card_CMS.tcl", help="template card for Delphes")
     common.add_argument("--no-constituents", default=False, action="store_true", help="disable (potentially intensive) constituent-based computations during histogramming")
+    common.add_argument("--gen-only", default=False, action="store_true", help="only make histograms of gen-level quantities")
     common.add_argument("--debug", default=False, action="store_true", help="enable detailed debug printouts during histogramming")
 
     parser = ArgumentParser(
@@ -170,5 +171,5 @@ if __name__=="__main__":
 
     if 'hist' in args["common"].steps:
 
-        Histogram.histogram(root_fname, helper, not args["common"].no_constituents, args["common"].debug)
+        Histogram.histogram(root_fname, helper, not args["common"].no_constituents, args["common"].gen_only, args["common"].debug)
         if args["common"].verbose: print(f'wrote histograms of {root_fname}')

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -739,7 +739,9 @@ class svjHelper(baseHelper):
 
         # metadata tracking
         self.always_included = ["channel","mmed","Nc","Nf","scale","mq","mpi","mrho","pvector","spectrum","gq","gchi"]
-        self.maybe_included = ["rinv","rinvpred","Ns"]
+        self.maybe_included = ["rinv","Ns"]
+        # included in metadata but *not* in name
+        self.meta_included = ["rinvpred"]
         self.special_formats = {
             "channel": "{1}-{0}",
             "spectrum": "{}-{}",
@@ -757,7 +759,7 @@ class svjHelper(baseHelper):
 
     def metadata(self):
         metadict = {param:getattr(self,param) for param in self.always_included}
-        metadict.update({param:getattr(self,param) for param in self.maybe_included if getattr(self,param,None) is not None})
+        metadict.update({param:getattr(self,param) for param in self.maybe_included+self.meta_included if getattr(self,param,None) is not None})
         metadict["stableIDs"] = self.stableIDs
         metadict["darkHadronIDs"] = self.darkHadronIDs
         metadict["darkHadronFinalIDs"] = self.darkHadronFinalIDs

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -778,6 +778,7 @@ class svjHelper(baseHelper):
             'HiddenValley:FSR = on',
             'HiddenValley:fragment = on',
             'HiddenValley:alphaOrder = 1',
+            'HiddenValley:setLambda = on',
             'HiddenValley:Lambda = {:g}'.format(self.scale),
             'HiddenValley:nFlav = {:d}'.format(self.Nf),
             'HiddenValley:probVector = {:g}'.format(self.pvector),

--- a/svjHelper.py
+++ b/svjHelper.py
@@ -721,8 +721,8 @@ class svjHelper(baseHelper):
         if self.rinv is not None:
             if self.rinv<0 or self.rinv>1:
                 raise ValueError(f'rinv {self.rinv} not allowed (0 <= rinv <= 1)')
-        if self.Nc is not None and self.Nf is not None and self.Ns is not None:
-            self.rinvpred = round(fcdc_rinv(Nf = self.Nf, Ns = self.Ns),3)
+        if self.Nf is not None and self.Ns is not None:
+            self.rinvpred = fcdc_rinv(Nf = self.Nf, Ns = self.Ns)
 
         # set up production channel
         self.channelHelper = hvChannel(self.channel, self)


### PR DESCRIPTION
Technical:
* Use [lcg-venv](https://github.com/kpedro88/lcg-venv) to manage Python packages
* Allow installing different Pythia versions
    * there are some customizations needed because of interface changes at certain minor versions. known customizations are included in the environment variables and `run_model`.
* Move to HepMC3 (for Pythia and Delphes)
* Add multiprocessing option to `run_fcdc_models.py` to generate multiple models in parallel
* Minor fixes to histograms, plotting after #17

Physics:
* Physics bug fix: activate `setLambda` parameter to allow setting dark QCD coupling/force via `Lambda` [1]
* Physics feature: pre-fragmentation analysis
    * add DarkPartonJets collection, clustered from the (last copies of) dark quarks and gluons
        * this required a small update to the [patched version of Delphes](https://github.com/cms-svj/delphes/tree/DarkHadronJets)
    * add card to disable HV fragmentation (i.e. formation of hadrons), used as: `./run_model ... --pythia cards/CMS_Common.txt cards/CMS_Tune_CP5.txt cards/no_HVfragment.txt`
    * add `--gen-only` option for histograms
* Remove `rinvpred` from model name (not an input of complete models, but rather an output)

[1]: More details: Pythia 8.3 ignores `HiddenValley:Lambda` if `setLambda` is not turned on. This was not the case in Pythia 8.2. Manual debug printouts show the change:
before: PYTHIA Warning in SimpleTimeShower::init: Hidden Valley  shower parameters: Lambda = 0.084721, alphaFSR = 0.147757 @ Q = 91.188000
after: PYTHIA Warning in SimpleTimeShower::init: Hidden Valley  shower parameters: Lambda = 10.000000, alphaFSR = 10.318440 @ Q = 91.188000
The proximate effect is increasing the number of dark hadrons produced in showers.