### PR TITLE
correct probVector value

### DIFF
--- a/Metaplot.py
+++ b/Metaplot.py
@@ -12,10 +12,10 @@ import itertools
 from common import set_plot_style, accumulate_data
 
 samples = [
-    {"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
-    {"name": "simp", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
-    {"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
-    {"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+    {"name": "FCDC", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+    {"name": "simp", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+    {"name": "FCDC (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-*_Nf-*_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*_Ns-*")},
+    {"name": "simp (3-body)", "models": glob("models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.333_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
 ]
 # account for two complete models with rinv=0.75
 for sample in samples:

--- a/NcPlots.py
+++ b/NcPlots.py
@@ -11,13 +11,13 @@ from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 from common import set_plot_style, resolve_models, accumulate_data
 
 samples = [
-    {"name": "FCDC Nc=3", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-3_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    {"name": "FCDC Nc=4", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-4_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    {"name": "FCDC Nc=5", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-5_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    {"name": "FCDC Nc=6", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-6_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    {"name": "FCDC Nc=7", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-7_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    {"name": "FCDC Nc=8", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-8_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-*")},
-    #{"name": "Simple", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
+    {"name": "FCDC Nc=3", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-3_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    {"name": "FCDC Nc=4", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-4_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    {"name": "FCDC Nc=5", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-5_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    {"name": "FCDC Nc=6", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-6_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    {"name": "FCDC Nc=7", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-7_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    {"name": "FCDC Nc=8", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-8_Nf-*_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-*")},
+    #{"name": "Simple", "models": resolve_models("/eos/uscms/store/user/easmith/svj/models/fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-*")},
 ]
 
 data = accumulate_data(samples)

--- a/Plots.py
+++ b/Plots.py
@@ -8,35 +8,10 @@ import pickle
 from magiconfig import ArgumentParser, ArgumentDefaultsRawHelpFormatter
 
 samples = [
-    {"name": r"FCDC", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
-    {"name": r"simp", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
-    {"name": r"FCDC (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
-    {"name": r"simp (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.5_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
-
-    #{"name": r"CMS", "model": "s-channel_mmed-1000_Nc-2_Nf-2_scale-35.1539_mq-10_mpi-20_mrho-20_pvector-0.75_spectrum-cms_rinv-0.3/"}
-    # {"name": r"CMS ($r_{\text{inv}} = 0.667$)", "model": "s-channel_mmed-1000_Nc-2_Nf-2_scale-35.1539_mq-10_mpi-20_mrho-20_pvector-0.75_spectrum-cms_rinv-0.666667"},
-    # {"name": r"Snowmass ($m_{\text{dark}} = 20\,\text{GeV}$)", "model": "s-channel_mmed-1000_Nc-3_Nf-3_scale-33.3333_mq-33.73_mpi-20_mrho-83.666_pvector-0.5_spectrum-snowmass_rinv-0"},
-    # {"name": r"fcdc_rinv0p5", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.5"},
-    # {"name": r"fcdc_rinv0p4", "model": "fcdc/s-channel_mmed-1000_Nc-4_Nf-4_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.4"},
-    # {"name": r"fcdc_rinv0p67", "model": "fcdc/s-channel_mmed-1000_Nc-4_Nf-4_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.666667"},
-    # {"name": r"fcdc_rinv0p33", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.333333"},
-    # {"name": r"fcdc_rinv0p58", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.583333"},
-    # {"name": r"fcdc_rinv0p75", "model": "fcdc/s-channel_mmed-1000_Nc-5_Nf-5_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.75"},
-    # {"name": r"fcdc_rinv0p28", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.285714"},
-    # {"name": r"fcdc_rinv0p51", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.514286"},
-    # {"name": r"fcdc_rinv0p69", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.685714"},
-    # {"name": r"fcdc_rinv0p8", "model": "fcdc/s-channel_mmed-1000_Nc-6_Nf-6_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.8"},
-    # {"name": r"fcdc_rinv0p25", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.25"},
-    # {"name": r"fcdc_rinv0p46", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.458333"},
-    # {"name": r"fcdc_rinv0p625", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.625"},
-    # {"name": r"fcdc_rinv0p75", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.75"},
-    # {"name": r"fcdc_rinv0p83", "model": "fcdc/s-channel_mmed-1000_Nc-7_Nf-7_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.833333"},
-    # {"name": r"fcdc_rinv0p22", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.222222"},
-    # {"name": r"fcdc_rinv0p41", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.412698"},
-    # {"name": r"fcdc_rinv0p57", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.571429"},
-    # {"name": r"fcdc_rinv0p7", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.698413"},
-    # {"name": r"fcdc_rinv0p79", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.793651"},
-    # {"name": r"fcdc_rinv0p85", "model": "fcdc/s-channel_mmed-1000_Nc-8_Nf-8_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.5_spectrum-fcdc_rinv-0.857143"},
+    {"name": r"FCDC", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
+    {"name": r"simp", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-10_mq-10.119_mpi-6_mrho-25.0998_pvector-0.333_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
+    {"name": r"FCDC (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.333_spectrum-fcdc_gq-0.25_gchi-0.333333_Ns-1"},
+    {"name": r"simp (3-body)", "model": "fcdc/s-channel_mmed-1000_Nc-3_Nf-3_scale-3.52941_mq-3.8666_mpi-6_mrho-11.2139_pvector-0.333_spectrum-fcdcSimp_gq-0.25_gchi-0.333333_rinv-0.5"},
 ]
 
 # stylistic options

--- a/configs/model_fcdc_base.py
+++ b/configs/model_fcdc_base.py
@@ -4,6 +4,8 @@ from magiconfig import MagiConfig
 config = MagiConfig()
 config.channel = 's'
 config.mmed = 1000
-config.pvector = 0.5
+# StringFlav:mesonUDvector = 0.5 in Monash tune (and CP5 tune)
+# StringFlav:mesonUDvector sets V/PS, while probVector sets V/(V+PS)
+config.pvector = 0.333
 config.spectrum = 'fcdc'
 config.gq = 0.25

--- a/configs/model_snowmass_base.py
+++ b/configs/model_snowmass_base.py
@@ -6,7 +6,9 @@ config.channel = 's'
 config.mmed = 1000
 config.Nc = 3
 config.Nf = 3
-config.pvector = 0.5
+# StringFlav:mesonUDvector = 0.5 in Monash tune (and CP5 tune)
+# StringFlav:mesonUDvector sets V/PS, while probVector sets V/(V+PS)
+config.pvector = 0.333
 # this rinv is only applied to diagonal pions; overall rinv value is (6+k)/9
 k = 1
 config.rinv = k/3


### PR DESCRIPTION
As is now noted in the [Pythia8 Hidden Valley documentation](https://pythia8.web.cern.ch/manuals/pythia8317/HiddenValleyProcesses.html) for `HiddenValley:probVector`:
> Note the difference relative to `StringFlav:mesonUDvector` and related ones, which set the ratio V/PS, whereas here V/(V+PS) is set.

Therefore, `mesonUDvector = probVector / (1 - probVector)`, since `probPseudoScalar = 1 - probVector`. If `mesonUDvector = 0.5` for SM QCD, the corresponding value is `probVector = mesonUDvector / (1 + mesonUDvector) = 0.333...`.

The final result after also incorporating the effect of `probKeepEta1 -> 0` is closer to 0.37 in terms of vector mesons actually produced, but as the input value, `probVector = 0.333` is the right setting.